### PR TITLE
Expand movement library across domains + add hip-hinge primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ For where Movit spreads fastest and the per-domain go-to-market plan, see
 
 ## Scope (v0.1)
 
-✅ Single-person fitness, stretching & posture · Mermaid-style DSL · ROM safety
-clamping · forward kinematics · ground-lock IK · live playground.
+✅ Single-person movement across fitness, physio, desk, dance, education & rehab ·
+Mermaid-style DSL · ROM safety clamping · forward kinematics · ground-lock **and
+reach-to-target IK** · hip-hinge · lying/seated poses · scene props (chair/wall/
+bar) · a single-DOF hand rig · live playground.
 
-⏳ Deferred: reach-IK, two-person / partner movements + collision detection,
-FBX/GLB export, hosted SaaS editor and the expert-verified motion marketplace.
+⏳ Deferred: two-person / partner movements + collision detection, deeper props
+(load, bands, rings), multi-joint fingers, FBX/GLB export, hosted SaaS editor and
+the expert-verified motion marketplace.
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ write Movit for you.
 The protocol and both libraries are **MIT-licensed** — the open core. See
 [`spec/SPEC.md`](spec/SPEC.md) for the full language and
 [`spec/llm-authoring.md`](spec/llm-authoring.md) for the authoring prompt.
+For where Movit spreads fastest and the per-domain go-to-market plan, see
+[`docs/market-research.md`](docs/market-research.md); for the engine roadmap,
+[`ROADMAP.md`](ROADMAP.md).
 
 ## Scope (v0.1)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,9 +25,10 @@ domain needs — so contributions land where they unlock the most.
 
 These are the unlocks, roughly in order of leverage:
 
-1. **Hip / waist hinge primitive** — today deadlift / forward-fold are faked as a
-   spinal roll-down. A true hip hinge unlocks deadlift, row, good-morning, hinge-based
-   yoga, and bending to interact with props.
+1. ~~**Hip / waist hinge primitive**~~ — ✅ **shipped (v0.1).** `pelvis: hinge <deg>`
+   tips the torso forward over the hips while the legs stay planted (the renderer
+   counter-rotates the hips). Powers `deadlift`, `bent-over-row`, `good-morning`,
+   and `bow`. Next: hinge with a loaded-bar prop.
 2. **Reach-IK (reach a world target)** — touch your toes, hand-to-opposite-knee,
    grab a bar, place a hand on a wall. Unlocks a huge share of physio, yoga, and any
    prop interaction.
@@ -62,8 +63,12 @@ Each prop is a small scene object + an anchor type; movements then reference it
 
 - One figure only; no props or external objects yet.
 - Forward kinematics + ground-locked hands/feet; **no reach-to-target IK**.
-- Hip/waist hinge is approximated by spinal flexion (so deadlift-class moves look
-  like a roll-down — curate around this until the hinge primitive lands).
 - Rig ends at the wrist (no fingers) and the head (no facial articulation).
 
 > Range-of-motion values are general literature data, not medical advice.
+
+---
+
+See [`docs/market-research.md`](docs/market-research.md) for where Movit spreads
+fastest, the per-domain go-to-market briefs, and which engine unlock opens which
+locked domain.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,16 +29,22 @@ These are the unlocks, roughly in order of leverage:
    tips the torso forward over the hips while the legs stay planted (the renderer
    counter-rotates the hips). Powers `deadlift`, `bent-over-row`, `good-morning`,
    and `bow`. Next: hinge with a loaded-bar prop.
-2. **Reach-IK (reach a world target)** — touch your toes, hand-to-opposite-knee,
-   grab a bar, place a hand on a wall. Unlocks a huge share of physio, yoga, and any
-   prop interaction.
-3. **Scene props with contact anchors** — objects the figure can stand on, sit on,
-   hang from, or push against, plus ground-lock-style anchors to them.
-4. **Lying & seated base poses** — supine / prone / quadruped / seated starting poses
-   (for floor yoga, mat Pilates, bed-based rehab, sit-to-stand on a real seat).
-5. **Hand / finger articulation** — grip and gesture (sign language, grasping props).
+2. ~~**Reach-IK (reach a world target)**~~ — ✅ **shipped.** `reach: <effector>
+   <target>` drives a hand/foot to a body landmark, the `floor`, or a prop anchor
+   via CCD. Powers `touch-toes`, `cross-body-reach`, `seated-forward-fold`, and
+   prop grips. Next: ROM-constrained reach + dual-hand targets.
+3. ~~**Scene props with contact anchors**~~ — ✅ **shipped (starter set).** `prop
+   chair|wall|bar` adds a scene object with named anchors (`seat`, `wall`, `bar`).
+   Powers `sit-to-stand`, `box-squat`, `wall-sit`, `dead-hang`, `hanging-knee-raise`.
+   Next: more props (bench, rings, bands), load cues, anchor-aware ground-lock.
+4. ~~**Lying & seated base poses**~~ — ✅ **shipped.** `supine | prone | seated`
+   start poses (grounded by a bounding-box drop). Powers `glute-bridge`,
+   `dead-bug`, `cobra`, `seated-forward-fold`. Next: quadruped + chair-seated.
+5. ~~**Hand / finger articulation**~~ — ✅ **shipped (single-DOF).** Per-finger
+   curl bones + `fingers` group. Powers `make-a-fist`, `pinch-grip`, `hand-wave`,
+   `finger-spell-demo`. Next: multi-joint fingers for accurate sign language.
 6. **Two-person + collision** — partner stretches, assisted rehab, contact sports
-   (already noted as deferred in the spec).
+   (still deferred in the spec).
 
 ## Prop / equipment library (future)
 
@@ -61,9 +67,13 @@ Each prop is a small scene object + an anchor type; movements then reference it
 
 ## Current limitations (honest)
 
-- One figure only; no props or external objects yet.
-- Forward kinematics + ground-locked hands/feet; **no reach-to-target IK**.
-- Rig ends at the wrist (no fingers) and the head (no facial articulation).
+- One figure only; partner work and collision are still deferred.
+- A **starter** prop set (chair / wall / bar) — no bench, rings, bands, or loaded
+  implements yet, and props sit at fixed default placements.
+- Reach-IK is **unconstrained** (no ROM limits on the solved chain) and props are
+  visual + reach anchors (no physical sit/lean solve).
+- Fingers are **single-DOF** curls — good for grip and rough gesture, not exact
+  sign language. The head has no facial articulation.
 
 > Range-of-motion values are general literature data, not medical advice.
 

--- a/docs/market-research.md
+++ b/docs/market-research.md
@@ -1,0 +1,159 @@
+# Movit — market research & go-to-market
+
+> Where Movit spreads fastest, who pulls hardest, and which engine unlock opens
+> which locked domain. Companion to [`../ROADMAP.md`](../ROADMAP.md) (engine
+> capabilities) and [`../spec/llm-authoring.md`](../spec/llm-authoring.md)
+> (how an LLM authors a movement).
+
+## 1. The thesis
+
+Movit is **"Mermaid for human movement."** A person describes a movement in
+words; an LLM writes a short `.movit` document; the browser parses it, clamps it
+to a safe range of motion, and renders an animated 3D mannequin — producing a
+**shareable URL**. The loop is:
+
+> **ask an LLM for a movement → it renders → share the link.**
+
+This is structurally different from video. A `.movit` doc is **editable text**:
+an LLM can generate it, a human can tweak one angle, a clinician can fork it, and
+it diffs in version control. Diffusion/video models hallucinate anatomy and can't
+be safely constrained; Movit's ROM clamp is a *correctness* feature, not a filter.
+Text is also how LLMs natively "think" about structure — so authoring is reliable
+and improves as models improve.
+
+### Why it can spread
+
+- **LLM-native.** The unit of creation is a code block any chat model emits. No
+  studio, no mocap, no rigging.
+- **Shareable by construction.** Every movement is a URL ([`movit-share`](../packages/movit-share)).
+  A link is the most viral object on the internet.
+- **Agent-native.** The [`movit-mcp`](../packages/movit-mcp) server lets Claude/
+  ChatGPT author, validate, and return a render link *inside the chat* — the
+  movement appears where the user already is.
+- **Safe to trust.** Clinical ROM limits mean shared links can't depict unsafe
+  joint angles — important for the health-adjacent buyers below.
+
+## 2. How we scored the domains
+
+Each domain is rated on four axes:
+
+| Axis | Question |
+| --- | --- |
+| **Engine-fit today** | Does it render cleanly on the v0.1 rig (1 figure, FK, ground-locked feet/hands, no props, no reach-IK)? |
+| **Customer pull** | Is there an acute, recurring need a free shareable demo satisfies? |
+| **Virality** | How naturally does output get shared, embedded, or re-prompted? |
+| **LLM-authorability** | Can a model reliably write correct docs with little context? |
+
+The four domains below score highest on **engine-fit × authorability** — they
+work *today*, so the catalog and the viral loop compound now rather than waiting
+on the roadmap.
+
+## 3. Target domains (ship now)
+
+### 3a. Anatomy & movement education — *top of funnel*
+
+- **Customer:** anatomy/kinesiology students & instructors, PT/OT/med students,
+  personal-trainer certifications, biology teachers, curious people.
+- **Aha use case:** "What is shoulder abduction?" → an isolated joint sweeps
+  through its plane, labeled. The answer is a *moving figure*, not a static
+  diagram.
+- **Viral loop:** an LLM answering an anatomy question embeds a Movit link;
+  teachers paste links into slides/LMS; students re-prompt for the next joint.
+- **Ships:** `shoulder-abduction-demo`, `hip-flexion-demo`, `knee-flexion-demo`,
+  `spine-rotation-demo`, `elbow-flexion-pronation`.
+- **Engine-fit:** ★★★★★ — single-joint ROM demos are *exactly* what the rig does.
+
+### 3b. Physiotherapy & rehab
+
+- **Customer:** physios, chiros, athletic trainers, and their patients running
+  home-exercise programs; post-op ROM protocols.
+- **Aha use case:** a clinician types a prescription and hands the patient a link
+  that *shows* the exercise, with a built-in safe-range guarantee.
+- **Viral loop:** clinician → patient link sharing is high-frequency and trusted;
+  patients forward to family; clinics build reusable libraries.
+- **Ships:** `heel-raises`, `standing-hamstring-curl`, `hip-abduction`,
+  `good-morning` (back-health hinge), plus existing `neck-rotation`,
+  `shoulder-stretch`.
+- **Engine-fit:** ★★★★☆ — the ROM clamp is a clinical feature; bands/balls and
+  lying poses are future (see roadmap).
+
+### 3c. Desk & workplace wellness
+
+- **Customer:** remote workers, HR/wellness programs, ergonomics consultants,
+  "stretch break" apps.
+- **Aha use case:** a recurring "do this every hour" prompt returns a fresh
+  60-second posture-reset animation.
+- **Viral loop:** Slack/Teams wellness bots posting a daily link; an LLM "stretch
+  break" habit; embeds on internal wikis.
+- **Ships:** `shoulder-rolls`, `neck-side-stretch`, `chest-opener`,
+  `overhead-reach-reset`, plus existing `posture-reset`, `spinal-twist`.
+- **Engine-fit:** ★★★★☆ — standing variants render today; true *seated* needs a
+  chair prop.
+
+### 3d. Sports, martial arts & **dance** — *flagship*
+
+- **Customer:** coaches, dancers/choreographers, martial-arts instructors,
+  general athletes warming up.
+- **Aha use case (sports/MA):** stances, strikes, and warm-up drills as
+  short, snappy, shareable clips — `front-kick`, `jab-cross`, `horse-stance`,
+  `bow`, `arm-circles`, `high-knee-march`.
+
+#### Dance / choreography — the flagship bet
+
+Dance is where the *editable-text* thesis is most magical: **you describe the
+movement in your head and watch it appear** — then nudge a beat, swap an arm
+position, extend the phrase, and re-share. It is inherently sequential,
+expressive, and social — exactly the content people share.
+
+- **Customer:** choreographers drafting and notating phrases, dance teachers,
+  students learning vocabulary, social dancers.
+- **Aha use case:** "give me an 8-count: plié, port de bras, relevé" →
+  `dance-phrase` renders a real phrase you can scrub, loop, and link.
+- **Viral loop:** dancers share phrase links; teachers assign them; students
+  re-prompt variations; the gallery becomes a browsable vocabulary.
+- **Ships:** `demi-plie`, `releve`, `tendu`, `port-de-bras`, and the combined
+  `dance-phrase` centerpiece.
+- **Engine-fit:** ★★★☆☆ today (turnout, plié, relevé, port de bras all render);
+  precise foot placement, traveling steps, and partner work are future.
+- **Long game:** a **shareable, LLM-authorable choreography notation** — Labanotation
+  was never going to be typed into a chat box; a `.movit` phrase is. If Movit
+  becomes the way people sketch and pass around movement, dance is the wedge.
+
+## 4. Spread mechanics
+
+- **MCP inside the assistant.** [`movit-mcp`](../packages/movit-mcp) puts authoring +
+  a render link directly in Claude/ChatGPT — distribution rides on assistants we
+  don't have to build an audience for.
+- **Links as the unit.** [`movit-share`](../packages/movit-share) makes every
+  movement a URL; links are forwarded, bookmarked, and embedded.
+- **Gallery grouped by domain.** The playground presets carry a `domain` and the
+  gallery auto-groups them (Education, Physiotherapy, Desk & posture, Martial
+  arts, Warm-up, Dance, Fitness, Yoga, Mobility) so breadth is visible on the
+  landing page and each domain has an obvious entry point.
+- **Education as top-of-funnel.** Anatomy demos answer questions millions already
+  ask LLMs daily; each answer can carry a link.
+- **Workplace cadence.** "Every hour" stretch prompts create recurring,
+  habit-driven link generation.
+- **Embeds.** A link that renders in an iframe drops Movit into LMSs, clinic
+  portals, and blog posts.
+
+## 5. Which engine unlock opens which domain
+
+From [`../ROADMAP.md`](../ROADMAP.md), in rough order of leverage:
+
+| Unlock | Domains it opens / deepens |
+| --- | --- |
+| **Hip-hinge** ✅ *shipped* | Fitness (deadlift, row, good-morning), back-health physio, martial-arts bow |
+| **Reach-to-target IK** | Big share of physio (touch toes, hand-to-knee), yoga, prop interaction |
+| **Scene props + contact anchors** | Loaded strength, pull-ups/rings, wall/chair work, bands |
+| **Lying / seated base poses** | Floor yoga, mat Pilates, bed-based rehab, true seated desk work |
+| **Hand / finger rig** | Sign language, grip, expressive gesture |
+| **Two-person + collision** | Partner stretches, assisted rehab, contact sports |
+
+The strategic read: **education + physio + desk + dance** monetize the rig as it
+exists today and build the catalog/virality flywheel; **reach-IK and props** are
+the next investments that convert the 🟡 domains in the roadmap into ✅.
+
+> ⚠️ Movit's range-of-motion values are general literature data, not medical
+> advice. Consult a qualified professional for physiotherapy or exercise
+> prescription.

--- a/docs/market-research.md
+++ b/docs/market-research.md
@@ -141,18 +141,20 @@ expressive, and social — exactly the content people share.
 
 From [`../ROADMAP.md`](../ROADMAP.md), in rough order of leverage:
 
-| Unlock | Domains it opens / deepens |
-| --- | --- |
-| **Hip-hinge** ✅ *shipped* | Fitness (deadlift, row, good-morning), back-health physio, martial-arts bow |
-| **Reach-to-target IK** | Big share of physio (touch toes, hand-to-knee), yoga, prop interaction |
-| **Scene props + contact anchors** | Loaded strength, pull-ups/rings, wall/chair work, bands |
-| **Lying / seated base poses** | Floor yoga, mat Pilates, bed-based rehab, true seated desk work |
-| **Hand / finger rig** | Sign language, grip, expressive gesture |
-| **Two-person + collision** | Partner stretches, assisted rehab, contact sports |
+| Unlock | Domains it opens / deepens | Status |
+| --- | --- | --- |
+| **Hip-hinge** | Fitness (deadlift, row, good-morning), back-health physio, martial-arts bow | ✅ shipped |
+| **Reach-to-target IK** | Big share of physio (touch toes, cross-body), yoga, prop interaction | ✅ shipped |
+| **Scene props + anchors** | Sit-to-stand, box squat, wall sit, dead hang / hanging knee raise | ✅ shipped (chair / wall / bar) |
+| **Lying / seated base poses** | Floor yoga, mat Pilates, bed-based rehab (glute bridge, dead bug, cobra) | ✅ shipped |
+| **Hand / finger rig** | Grip rehab, expressive gesture, rough finger-spelling | ✅ shipped (single-DOF) |
+| **Two-person + collision** | Partner stretches, assisted rehab, contact sports | ⏳ deferred |
 
-The strategic read: **education + physio + desk + dance** monetize the rig as it
-exists today and build the catalog/virality flywheel; **reach-IK and props** are
-the next investments that convert the 🟡 domains in the roadmap into ✅.
+The strategic read: **education + physio + desk + dance** monetize the rig and
+build the catalog/virality flywheel. With reach-IK, props, lying/seated poses, and
+a hand rig now shipped, the roadmap's 🟡 domains (functional/elderly care, floor
+yoga, loaded strength, gesture) are reachable today; the remaining frontier is
+deeper props (load, bands, rings), ROM-constrained reach, and two-person work.
 
 > ⚠️ Movit's range-of-motion values are general literature data, not medical
 > advice. Consult a qualified professional for physiotherapy or exercise

--- a/packages/movit-language/src/vocab.ts
+++ b/packages/movit-language/src/vocab.ts
@@ -12,26 +12,32 @@ export { JOINT_NAMES, ACTION_NAMES, EASINGS };
 export const KINDS = ["exercise", "stretch", "posture"];
 
 /** Recognised start poses (`pose start = ...`). */
-export const POSES = ["neutral", "standing", "plank"];
+export const POSES = ["neutral", "standing", "plank", "supine", "prone", "seated"];
 
 /** Effectors that can be ground-locked. */
 export const EFFECTORS = ["hands", "feet"];
 
+/** Reach effectors (friendly aliases) and the scene props that supply anchors. */
+export const REACH_EFFECTORS = ["hand_left", "hand_right", "foot_left", "foot_right"];
+export const PROPS = ["chair", "wall", "bar"];
+
 /** Top-level directives (excluding the `movit` header keyword). */
-export const TOP_KEYWORDS = ["rig", "pose", "step", "repeat"];
+export const TOP_KEYWORDS = ["rig", "prop", "pose", "step", "repeat"];
 
 /** Keywords valid as step children. */
-export const CHILD_KEYWORDS = ["ground-lock", "cue"];
+export const CHILD_KEYWORDS = ["ground-lock", "reach", "cue"];
 
 /** Short docs surfaced on hover and as completion detail. */
 export const KEYWORD_DOCS: Record<string, string> = {
   movit: 'Document header — `movit <kind> "<name>"`.',
   rig: "Selects the rig (currently `humanoid`).",
-  pose: "Sets the starting pose — `pose start = standing | neutral | plank`.",
+  prop: "Adds a scene object — `prop chair | wall | bar`. Supplies reach anchors.",
+  pose: "Sets the starting pose — `pose start = standing | neutral | plank | supine | prone | seated`.",
   start: "Used in `pose start = <pose>`.",
   step: 'A movement phase — `step "<name>" <Ns> <easing>:`.',
   repeat: "How many times the movement loops.",
   "ground-lock": "Pins effectors (hands / feet) to the floor for this phase.",
+  reach: "Drives an effector to a target via IK — `reach: hand_left ankle_left`.",
   cue: "A short coaching cue shown while this phase plays.",
   hold: "Keep the joint at its neutral / rest angle.",
 };

--- a/packages/movit-parser/src/clamp.ts
+++ b/packages/movit-parser/src/clamp.ts
@@ -42,6 +42,7 @@ export function resolve(ast: AstDoc): ResolveResult {
     name: ast.name,
     rig: ast.rig,
     ...(ast.startPose ? { startPose: ast.startPose } : {}),
+    props: ast.props,
     repeat: ast.repeat,
     phases,
   };
@@ -119,6 +120,7 @@ function resolveStep(
     easing: step.easing as Phase["easing"],
     targets,
     groundLock: step.groundLock,
+    reaches: step.reaches,
     ...(step.cue ? { cue: step.cue } : {}),
   };
 }

--- a/packages/movit-parser/src/index.ts
+++ b/packages/movit-parser/src/index.ts
@@ -36,6 +36,7 @@ export type {
   Easing,
   EulerDeg,
   JointTarget,
+  ReachTarget,
   Phase,
   MovitIR,
   Warning,

--- a/packages/movit-parser/src/joints.ts
+++ b/packages/movit-parser/src/joints.ts
@@ -31,6 +31,18 @@ export const BONES = [
   "knee_right",
   "ankle_left",
   "ankle_right",
+
+  // Hand rig: one curl bone per finger (single DOF), off each wrist.
+  "thumb_left",
+  "index_left",
+  "middle_left",
+  "ring_left",
+  "pinky_left",
+  "thumb_right",
+  "index_right",
+  "middle_right",
+  "ring_right",
+  "pinky_right",
 ] as const;
 
 export type BoneId = (typeof BONES)[number];
@@ -38,6 +50,21 @@ export type BoneId = (typeof BONES)[number];
 const BONE_SET = new Set<string>(BONES);
 
 /** Symmetric DSL group names → the bones they expand to. */
+const FINGERS_LEFT: BoneId[] = [
+  "thumb_left",
+  "index_left",
+  "middle_left",
+  "ring_left",
+  "pinky_left",
+];
+const FINGERS_RIGHT: BoneId[] = [
+  "thumb_right",
+  "index_right",
+  "middle_right",
+  "ring_right",
+  "pinky_right",
+];
+
 const GROUPS: Record<string, BoneId[]> = {
   shoulders: ["shoulder_left", "shoulder_right"],
   elbows: ["elbow_left", "elbow_right"],
@@ -45,6 +72,10 @@ const GROUPS: Record<string, BoneId[]> = {
   hips: ["hip_left", "hip_right"],
   knees: ["knee_left", "knee_right"],
   ankles: ["ankle_left", "ankle_right"],
+  // Finger groups: curl one hand, or both with `fingers`.
+  fingers_left: FINGERS_LEFT,
+  fingers_right: FINGERS_RIGHT,
+  fingers: [...FINGERS_LEFT, ...FINGERS_RIGHT],
 };
 
 /** Symmetric group names usable as joints in the DSL (e.g. "shoulders"). */

--- a/packages/movit-parser/src/joints.ts
+++ b/packages/movit-parser/src/joints.ts
@@ -81,6 +81,11 @@ const ACTIONS: Record<string, ActionAxis> = {
   pronate: { axis: "y", sign: -1 },
   dorsiflex: { axis: "x", sign: 1 },
   plantarflex: { axis: "x", sign: -1 },
+  // Hip hinge: tip the torso forward over the hip line (deadlift, row, bow,
+  // good-morning). Applied to the `pelvis`; sign -1 tips the figure forward
+  // (same sagittal direction as spine flex). The renderer counter-rotates the
+  // hips so the legs stay planted — see movit-render/src/timeline.ts.
+  hinge: { axis: "x", sign: -1 },
 };
 
 /** Every semantic action name the DSL accepts (e.g. "flex", "abduct"). */

--- a/packages/movit-parser/src/parser.ts
+++ b/packages/movit-parser/src/parser.ts
@@ -16,12 +16,18 @@ export interface AstJointTarget {
   line: number;
 }
 
+export interface AstReach {
+  effector: string;
+  target: string;
+}
+
 export interface AstStep {
   name: string;
   durationSec: number;
   easing: string;
   targets: AstJointTarget[];
   groundLock: string[];
+  reaches: AstReach[];
   cue?: string;
   line: number;
 }
@@ -31,6 +37,7 @@ export interface AstDoc {
   name: string;
   rig: string;
   startPose?: string;
+  props: string[];
   repeat: number;
   steps: AstStep[];
 }
@@ -79,6 +86,7 @@ export function parseToAst(source: string): ParseAstResult {
     kind: ht[1].value,
     name: ht[2].value,
     rig: "humanoid",
+    props: [],
     repeat: 1,
     steps: [],
   };
@@ -95,6 +103,13 @@ export function parseToAst(source: string): ParseAstResult {
         const r = word(t[1]);
         if (!r) errors.push({ line: ln.line, message: "rig requires a name" });
         else doc.rig = r;
+        break;
+      }
+      case "prop": {
+        // `prop <type>` — a scene object (chair | wall | bar), repeatable.
+        const p = word(t[1]);
+        if (!p) errors.push({ line: ln.line, message: "prop requires a type" });
+        else doc.props.push(p);
         break;
       }
       case "pose": {
@@ -136,6 +151,7 @@ export function parseToAst(source: string): ParseAstResult {
           easing,
           targets: [],
           groundLock: [],
+          reaches: [],
           line: ln.line,
         };
         doc.steps.push(current);
@@ -174,6 +190,18 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
       .filter((tok) => tok.type === "word")
       .map((tok) => tok.value);
     current.groundLock = effectors;
+    return null;
+  }
+
+  if (head === "reach") {
+    // `reach: <effector> <target>` — drive an effector to a world target via IK.
+    if (!current) return { line: ln.line, message: "`reach` outside of a step" };
+    const effector = t[2]?.type === "word" ? t[2].value : null;
+    const target = t[3]?.type === "word" ? t[3].value : null;
+    if (t[1]?.type !== "colon" || !effector || !target) {
+      return { line: ln.line, message: "expected `reach: <effector> <target>`" };
+    }
+    current.reaches.push({ effector, target });
     return null;
   }
 

--- a/packages/movit-parser/src/rom.ts
+++ b/packages/movit-parser/src/rom.ts
@@ -85,6 +85,17 @@ const ROM: Record<string, ActionLimits> = {
     "rotate-in": { min: 0, max: 80 },
     "rotate-out": { min: 0, max: 80 },
   },
+  // --- Hand / fingers (single-DOF curl per finger) ---
+  index: { flex: { min: 0, max: 100 }, extend: { min: 0, max: 20 } },
+  middle: { flex: { min: 0, max: 100 }, extend: { min: 0, max: 20 } },
+  ring: { flex: { min: 0, max: 100 }, extend: { min: 0, max: 20 } },
+  pinky: { flex: { min: 0, max: 100 }, extend: { min: 0, max: 20 } },
+  thumb: {
+    flex: { min: 0, max: 80 },
+    extend: { min: 0, max: 20 },
+    abduct: { min: 0, max: 50 },
+    adduct: { min: 0, max: 30 },
+  },
 };
 
 import { boneType } from "./joints.js";

--- a/packages/movit-parser/src/rom.ts
+++ b/packages/movit-parser/src/rom.ts
@@ -55,6 +55,13 @@ const ROM: Record<string, ActionLimits> = {
     dorsiflex: { min: 0, max: 15 },
     plantarflex: { min: 0, max: 50 },
   },
+  // --- Pelvis / hip-hinge (trunk-on-thigh angle) ---
+  // The hinge pivots the torso forward over the hip line while the legs stay
+  // vertical. ~120° is a deep hip-dominant fold (athletic deadlift / forward
+  // fold); beyond that the movement is spinal flexion, not a hinge.
+  pelvis: {
+    hinge: { min: 0, max: 120 },
+  },
   // --- Axial (conservative literature values) ---
   spine: {
     flex: { min: 0, max: 90 },

--- a/packages/movit-parser/src/schema.ts
+++ b/packages/movit-parser/src/schema.ts
@@ -20,12 +20,18 @@ const jointTargetSchema = z.object({
   line: z.number(),
 });
 
+const reachSchema = z.object({
+  effector: z.string().min(1),
+  target: z.string().min(1),
+});
+
 const stepSchema = z.object({
   name: z.string(),
   durationSec: z.number().positive(),
   easing: z.enum(EASINGS),
   targets: z.array(jointTargetSchema),
   groundLock: z.array(z.string()),
+  reaches: z.array(reachSchema),
   cue: z.string().optional(),
   line: z.number(),
 });
@@ -35,6 +41,7 @@ const docSchema = z.object({
   name: z.string().min(1),
   rig: z.string().min(1),
   startPose: z.string().optional(),
+  props: z.array(z.string()),
   repeat: z.number().int().positive(),
   steps: z.array(stepSchema),
 });

--- a/packages/movit-parser/src/types.ts
+++ b/packages/movit-parser/src/types.ts
@@ -26,14 +26,26 @@ export interface JointTarget {
   euler: EulerDeg;
 }
 
+/**
+ * A reach-to-target goal for a phase: drive an effector to a world point solved
+ * by inverse kinematics. `target` is a body landmark bone id (e.g. `ankle_left`),
+ * the keyword `floor`, or a prop anchor name (e.g. `bar`).
+ */
+export interface ReachTarget {
+  effector: string;
+  target: string;
+}
+
 /** One concurrent phase of a movement (e.g. "Lower" in a push-up). */
 export interface Phase {
   name: string;
   durationSec: number;
   easing: Easing;
   targets: JointTarget[];
-  /** Effector groups pinned to the floor for this phase, e.g. ["hands", "feet"]. */
+  /** Effector groups / prop anchors pinned for this phase, e.g. ["hands", "feet"]. */
   groundLock: string[];
+  /** Reach-IK goals active during this phase. */
+  reaches: ReachTarget[];
   cue?: string;
 }
 
@@ -45,6 +57,8 @@ export interface MovitIR {
   name: string;
   rig: string;
   startPose?: string;
+  /** Scene props declared with `prop <type>`, e.g. ["chair", "bar"]. */
+  props: string[];
   repeat: number;
   phases: Phase[];
 }

--- a/packages/movit-parser/test/examples.test.ts
+++ b/packages/movit-parser/test/examples.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { parse } from "../src/index.js";
+
+// Every bundled example must parse cleanly AND stay within ROM (zero warnings),
+// so the gallery never ships a broken or clamped demo. This also guards future
+// additions: drop a `.movit` in spec/examples and it is validated automatically.
+const EXAMPLES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../spec/examples",
+);
+
+const files = readdirSync(EXAMPLES_DIR).filter((f) => f.endsWith(".movit"));
+
+describe("bundled examples", () => {
+  it("finds the example documents", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s parses with no errors and no ROM warnings", (file) => {
+    const source = readFileSync(join(EXAMPLES_DIR, file), "utf8");
+    const { ir, errors, warnings } = parse(source);
+    // Surface the offending detail in the failure message.
+    expect({ file, errors }).toEqual({ file, errors: [] });
+    expect({ file, warnings }).toEqual({ file, warnings: [] });
+    expect(ir).not.toBeNull();
+    expect(ir!.phases.length).toBeGreaterThan(0);
+  });
+});
+
+describe("hip-hinge action", () => {
+  const HINGE = [
+    'movit exercise "Hinge"',
+    "  rig humanoid",
+    "  pose start = standing",
+    '  step "Lower" 2s ease-in-out:',
+    "    pelvis: hinge 80",
+    "    ground-lock: feet",
+    "  repeat 2",
+  ].join("\n");
+
+  it("accepts a pelvis hinge within ROM with no warnings", () => {
+    const { ir, errors, warnings } = parse(HINGE);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    const pelvis = ir!.phases[0]!.targets.find((t) => t.boneId === "pelvis")!;
+    // hinge tips the torso forward — same sagittal direction as spine flex (-X).
+    expect(pelvis.euler.x).toBe(-80);
+  });
+
+  it("clamps an over-deep hinge to the pelvis ROM ceiling", () => {
+    const src = HINGE.replace("hinge 80", "hinge 200");
+    const { ir, warnings } = parse(src);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.clamped).toBe(120);
+    const pelvis = ir!.phases[0]!.targets.find((t) => t.boneId === "pelvis")!;
+    expect(pelvis.euler.x).toBe(-120);
+  });
+});

--- a/packages/movit-render/src/index.ts
+++ b/packages/movit-render/src/index.ts
@@ -10,9 +10,11 @@
 
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import type { MovitIR } from "movit-parser";
+import type { MovitIR, ReachTarget } from "movit-parser";
 import { buildMannequin, type Mannequin } from "./mannequin.js";
 import { buildTimeline, type BuiltTimeline, type PhaseSegment } from "./timeline.js";
+import { solveCCD } from "./ik.js";
+import { buildProps, type PropScene } from "./props.js";
 
 const DEG = Math.PI / 180;
 
@@ -126,6 +128,10 @@ export function createViewer(
 
   let timeline: BuiltTimeline | null = null;
   let groundTargets = new Map<string, THREE.Vector3>();
+  // World-space anchor points contributed by scene props (chair seat, bar grip,
+  // wall surface). Populated when a doc declares props; empty otherwise.
+  let propAnchors = new Map<string, THREE.Vector3>();
+  let propScene: PropScene | null = null;
   let time = 0;
   let speed = 1;
   let playing = false;
@@ -160,15 +166,14 @@ export function createViewer(
   }
 
   function groundFigure(): void {
+    // Drop the whole figure so its lowest point rests on the floor. Using the
+    // mesh bounding-box min (not just hand/foot joints) means ANY pose grounds
+    // correctly — standing/plank rest on feet/hands, while supine/prone/seated
+    // poses rest on the back, chest, or glutes.
     mannequin.root.updateMatrixWorld(true);
-    let minY = Infinity;
-    for (const id of ["wrist_left", "wrist_right", "ankle_left", "ankle_right"]) {
-      const node = mannequin.bones.get(id);
-      if (!node) continue;
-      minY = Math.min(minY, node.getWorldPosition(new THREE.Vector3()).y);
-    }
-    if (Number.isFinite(minY)) {
-      mannequin.root.position.y -= minY;
+    const box = new THREE.Box3().setFromObject(mannequin.root);
+    if (Number.isFinite(box.min.y)) {
+      mannequin.root.position.y -= box.min.y;
       mannequin.root.updateMatrixWorld(true);
     }
   }
@@ -262,6 +267,64 @@ export function createViewer(
     }
   }
 
+  // Friendly DSL effector aliases → the distal bone whose world position is
+  // driven to the reach target.
+  const EFFECTOR_BONE: Record<string, string> = {
+    hand_left: "wrist_left",
+    hand_right: "wrist_right",
+    foot_left: "ankle_left",
+    foot_right: "ankle_right",
+  };
+
+  /** The rotatable joint chain (proximal → distal) that moves an effector. */
+  function reachChain(effectorBone: string): THREE.Object3D[] {
+    const side = effectorBone.endsWith("_left") ? "left" : "right";
+    const ids = effectorBone.startsWith("wrist")
+      ? [`shoulder_${side}`, `elbow_${side}`]
+      : effectorBone.startsWith("ankle")
+        ? [`hip_${side}`, `knee_${side}`]
+        : [];
+    return ids
+      .map((id) => mannequin.bones.get(id))
+      .filter((n): n is THREE.Object3D => !!n);
+  }
+
+  /** Resolve a reach target name to a world point: floor / prop anchor / landmark. */
+  function resolveReachTarget(
+    target: string,
+    effector: THREE.Object3D,
+  ): THREE.Vector3 | null {
+    if (target === "floor") {
+      const p = effector.getWorldPosition(new THREE.Vector3());
+      p.y = 0;
+      return p;
+    }
+    const anchor = propAnchors.get(target);
+    if (anchor) return anchor.clone();
+    const bone = mannequin.bones.get(target);
+    if (bone) return bone.getWorldPosition(new THREE.Vector3());
+    return null;
+  }
+
+  /**
+   * Reach-IK: drive each active effector to its world target with CCD. Runs
+   * AFTER ground-lock so landmark/floor targets are resolved against the final
+   * root placement. The chain is the arm (hand) or the leg (foot); other joints
+   * keep their authored FK pose.
+   */
+  function applyReaches(reaches: ReachTarget[]): void {
+    for (const r of reaches) {
+      const effectorBone = EFFECTOR_BONE[r.effector] ?? r.effector;
+      const effector = mannequin.bones.get(effectorBone);
+      if (!effector) continue;
+      const target = resolveReachTarget(r.target, effector);
+      if (!target) continue;
+      const joints = reachChain(effectorBone);
+      if (joints.length === 0) continue;
+      solveCCD({ joints, effector, target }, 12);
+    }
+  }
+
   function frameCamera(): void {
     // Auto-frame the figure: fit its bounding box, keep a pleasant angle.
     const box = new THREE.Box3().setFromObject(mannequin.root);
@@ -288,6 +351,7 @@ export function createViewer(
       const info = timeline.sample(time, mannequin.bones);
       mannequin.root.updateMatrixWorld(true);
       applyGroundLock(info.groundLock);
+      applyReaches(info.reaches);
       if (info.phaseName !== lastPhaseName) {
         lastPhaseName = info.phaseName;
         phaseCb({ phaseName: info.phaseName, ...(info.cue ? { cue: info.cue } : {}) });
@@ -331,6 +395,18 @@ export function createViewer(
       timeline = buildTimeline(ir);
       time = 0;
       lastPhaseName = "";
+      // Scene props: tear down any previous set, build the declared ones, and
+      // expose their anchors to reach-IK.
+      if (propScene) {
+        scene.remove(propScene.group);
+        disposeTree(propScene.group);
+      }
+      propScene = ir.props.length > 0 ? buildProps(ir.props) : null;
+      propAnchors = propScene?.anchors ?? new Map();
+      if (propScene) {
+        enableShadows(propScene.group);
+        scene.add(propScene.group);
+      }
       // Reset every bone to rest — otherwise joints from a previous movement
       // that this document doesn't touch would persist (e.g. bent legs from a
       // squat showing under a biceps curl).
@@ -408,7 +484,21 @@ function enableShadows(root: THREE.Object3D): void {
   });
 }
 
+/** Free GPU resources for a discarded subtree (prop set swapped on reload). */
+function disposeTree(root: THREE.Object3D): void {
+  root.traverse((obj) => {
+    const mesh = obj as THREE.Mesh;
+    if (mesh.isMesh) {
+      mesh.geometry?.dispose();
+      const mat = mesh.material;
+      if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+      else mat?.dispose();
+    }
+  });
+}
+
 export { buildMannequin } from "./mannequin.js";
 export { buildTimeline } from "./timeline.js";
 export { solveCCD } from "./ik.js";
+export { buildProps, type PropScene } from "./props.js";
 export type { PhaseSegment } from "./timeline.js";

--- a/packages/movit-render/src/mannequin.ts
+++ b/packages/movit-render/src/mannequin.ts
@@ -51,6 +51,20 @@ const SKELETON: BoneSpec[] = [
   { id: "hip_right", parent: "pelvis", offset: [-0.1, -0.06, 0], radius: 0.06 },
   { id: "knee_right", parent: "hip_right", offset: [0, -0.45, 0], radius: 0.05 },
   { id: "ankle_right", parent: "knee_right", offset: [0, -0.43, 0], radius: 0.04 },
+
+  // Fingers — short single-segment digits off each wrist, splayed in X and
+  // angled slightly forward (+Z, palm-side). One curl DOF each (flex).
+  { id: "thumb_left", parent: "wrist_left", offset: [0.035, -0.04, 0.025], radius: 0.014 },
+  { id: "index_left", parent: "wrist_left", offset: [0.025, -0.085, 0.012], radius: 0.013 },
+  { id: "middle_left", parent: "wrist_left", offset: [0.008, -0.092, 0.012], radius: 0.013 },
+  { id: "ring_left", parent: "wrist_left", offset: [-0.01, -0.088, 0.012], radius: 0.013 },
+  { id: "pinky_left", parent: "wrist_left", offset: [-0.028, -0.075, 0.012], radius: 0.012 },
+
+  { id: "thumb_right", parent: "wrist_right", offset: [-0.035, -0.04, 0.025], radius: 0.014 },
+  { id: "index_right", parent: "wrist_right", offset: [-0.025, -0.085, 0.012], radius: 0.013 },
+  { id: "middle_right", parent: "wrist_right", offset: [-0.008, -0.092, 0.012], radius: 0.013 },
+  { id: "ring_right", parent: "wrist_right", offset: [0.01, -0.088, 0.012], radius: 0.013 },
+  { id: "pinky_right", parent: "wrist_right", offset: [0.028, -0.075, 0.012], radius: 0.012 },
 ];
 
 /** Build the mannequin. `material` lets the playground theme it. */

--- a/packages/movit-render/src/poses.ts
+++ b/packages/movit-render/src/poses.ts
@@ -39,10 +39,38 @@ const PLANK: PoseSpec = {
 // Standing, ready position (alias of neutral for now).
 const STANDING: PoseSpec = NEUTRAL;
 
+// Lying face-up. Rotating the standing figure -90° about X lays it on its back:
+// the original front (+Z) ends up facing the ceiling (+Y) and the head points
+// toward -Z. groundFigure() (bounding-box drop) then rests the back on the floor.
+const SUPINE: PoseSpec = {
+  root: { position: [0, 0.5, 0], rotationDeg: [-90, 0, 0] },
+  joints: {},
+};
+
+// Lying face-down (+90° about X): the front faces the floor, head toward +Z.
+const PRONE: PoseSpec = {
+  root: { position: [0, 0.5, 0], rotationDeg: [90, 0, 0] },
+  joints: {},
+};
+
+// Long-sit on the floor: torso upright, hips flexed 90° so the legs extend
+// forward, knees straight. (Hip flexion resolves to -X in the rig, matching the
+// parser's flexion sign.) groundFigure() drops the glutes/legs to the floor.
+const SEATED: PoseSpec = {
+  root: { position: [0, 0.5, 0], rotationDeg: [0, 0, 0] },
+  joints: {
+    hip_left: [-90, 0, 0],
+    hip_right: [-90, 0, 0],
+  },
+};
+
 const POSES: Record<string, PoseSpec> = {
   neutral: NEUTRAL,
   standing: STANDING,
   plank: PLANK,
+  supine: SUPINE,
+  prone: PRONE,
+  seated: SEATED,
 };
 
 export function poseFor(name: string | undefined): PoseSpec {

--- a/packages/movit-render/src/props.ts
+++ b/packages/movit-render/src/props.ts
@@ -1,0 +1,70 @@
+/**
+ * Scene props — objects the figure sits on, leans against, or grips.
+ *
+ * A prop is a simple low-poly mesh at a fixed default transform plus named
+ * **anchors**: world-space contact points the movement can reference from a
+ * `reach:` line (e.g. `reach: hand_left bar`). Props are NOT parented to the
+ * mannequin — they live in the world and the figure moves to meet them.
+ *
+ * Default placement is chosen so each prop sits where its movements need it and
+ * distinct props don't collide: the chair is just behind the figure, the wall
+ * behind that, the pull-up bar overhead.
+ */
+
+import * as THREE from "three";
+
+export interface PropScene {
+  /** All prop meshes; add this to the scene. */
+  group: THREE.Group;
+  /** Anchor name → world-space contact point, merged into reach/ground-lock. */
+  anchors: Map<string, THREE.Vector3>;
+}
+
+/** Build the declared props (`chair | wall | bar`). Unknown types are ignored. */
+export function buildProps(types: string[], material?: THREE.Material): PropScene {
+  const group = new THREE.Group();
+  group.name = "movit-props";
+  const anchors = new Map<string, THREE.Vector3>();
+  const mat =
+    material ??
+    new THREE.MeshStandardMaterial({ color: 0x6b7280, roughness: 0.8, metalness: 0.05 });
+
+  for (const type of types) {
+    if (type === "chair") {
+      const seatH = 0.5;
+      const seat = box(0.42, 0.06, 0.42, mat);
+      seat.position.set(0, seatH, -0.16);
+      const back = box(0.42, 0.5, 0.06, mat);
+      back.position.set(0, seatH + 0.28, -0.34);
+      group.add(seat, back, leg(mat, 0.18, -0.0), leg(mat, -0.18, -0.0), leg(mat, 0.18, -0.32), leg(mat, -0.18, -0.32));
+      anchors.set("seat", new THREE.Vector3(0, seatH + 0.03, -0.12));
+    } else if (type === "bar") {
+      const barH = 1.95;
+      const bar = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.025, 0.025, 1.2, 12),
+        mat,
+      );
+      bar.rotation.z = Math.PI / 2; // horizontal, along X
+      bar.position.set(0, barH, 0);
+      group.add(bar);
+      anchors.set("bar", new THREE.Vector3(0, barH, 0));
+    } else if (type === "wall") {
+      const wall = box(2.2, 2.6, 0.1, mat);
+      wall.position.set(0, 1.3, -0.34);
+      group.add(wall);
+      anchors.set("wall", new THREE.Vector3(0, 0.9, -0.29));
+    }
+  }
+
+  return { group, anchors };
+}
+
+function box(w: number, h: number, d: number, mat: THREE.Material): THREE.Mesh {
+  return new THREE.Mesh(new THREE.BoxGeometry(w, h, d), mat);
+}
+
+function leg(mat: THREE.Material, x: number, z: number): THREE.Mesh {
+  const m = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.5, 0.05), mat);
+  m.position.set(x, 0.25, z);
+  return m;
+}

--- a/packages/movit-render/src/timeline.ts
+++ b/packages/movit-render/src/timeline.ts
@@ -8,7 +8,7 @@
  */
 
 import * as THREE from "three";
-import type { MovitIR } from "movit-parser";
+import type { MovitIR, ReachTarget } from "movit-parser";
 import { poseFor, type PoseSpec } from "./poses.js";
 
 const DEG = Math.PI / 180;
@@ -23,6 +23,7 @@ interface Keyframe {
   easing: Easing;
   quats: Map<string, THREE.Quaternion>;
   groundLock: string[];
+  reaches: ReachTarget[];
 }
 
 /** A phase as a time span on the timeline, for scrubber markers / ribbon. */
@@ -44,7 +45,7 @@ export interface BuiltTimeline {
   sample(
     t: number,
     bones: Map<string, THREE.Object3D>,
-  ): { phaseName: string; cue?: string; groundLock: string[] };
+  ): { phaseName: string; cue?: string; groundLock: string[]; reaches: ReachTarget[] };
 }
 
 function eulerToQuat([x, y, z]: EulerDegTuple): THREE.Quaternion {
@@ -76,6 +77,7 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     easing: "linear",
     quats: snapshot(curr),
     groundLock: [],
+    reaches: [],
   });
 
   let t = 0;
@@ -91,6 +93,7 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
       easing: phase.easing,
       quats: snapshot(curr),
       groundLock: phase.groundLock,
+      reaches: phase.reaches,
     });
   }
 
@@ -103,6 +106,7 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     easing: "ease-in-out",
     quats: snapshot(new Map(baseJoints)),
     groundLock: [],
+    reaches: [],
   });
 
   // Fill every keyframe with the full bone set (missing → identity).
@@ -153,7 +157,12 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
         if (!node) continue;
         node.quaternion.slerpQuaternions(a.quats.get(bone)!, b.quats.get(bone)!, eased);
       }
-      return { phaseName: b.name, ...(b.cue ? { cue: b.cue } : {}), groundLock: b.groundLock };
+      return {
+        phaseName: b.name,
+        ...(b.cue ? { cue: b.cue } : {}),
+        groundLock: b.groundLock,
+        reaches: b.reaches,
+      };
     },
   };
 }

--- a/packages/movit-render/src/timeline.ts
+++ b/packages/movit-render/src/timeline.ts
@@ -161,5 +161,19 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
 function snapshot(curr: Map<string, EulerDegTuple>): Map<string, THREE.Quaternion> {
   const out = new Map<string, THREE.Quaternion>();
   for (const [bone, euler] of curr) out.set(bone, eulerToQuat(euler));
+
+  // Hip-hinge coupling. The `pelvis` is the shared parent of both the torso and
+  // the legs, so a pelvis X-rotation tips the WHOLE figure forward — torso and
+  // legs alike. A real hip hinge keeps the legs planted and pivots only the
+  // torso over the hip line, so counter-rotate the hips by the same X angle:
+  // the thighs (hence shins and feet) stay world-vertical while the torso tips.
+  // The feet ground-lock (index.ts) then drops the figure so the feet rest flat.
+  const pelvisX = curr.get("pelvis")?.[0] ?? 0;
+  if (pelvisX !== 0) {
+    for (const hip of ["hip_left", "hip_right"]) {
+      const [hx, hy, hz] = curr.get(hip) ?? [0, 0, 0];
+      out.set(hip, eulerToQuat([hx - pelvisX, hy, hz]));
+    }
+  }
   return out;
 }

--- a/packages/movit-render/test/render.test.ts
+++ b/packages/movit-render/test/render.test.ts
@@ -3,13 +3,25 @@ import * as THREE from "three";
 import { buildMannequin } from "../src/mannequin.js";
 import { buildTimeline } from "../src/timeline.js";
 import { solveCCD } from "../src/ik.js";
+import { poseFor } from "../src/poses.js";
+import { buildProps } from "../src/props.js";
 import { parse } from "movit-parser";
 
+const DEG = Math.PI / 180;
+
 describe("mannequin", () => {
-  it("exposes all 17 named bones", () => {
+  it("exposes all 27 named bones (incl. fingers)", () => {
     const m = buildMannequin();
-    expect(m.bones.size).toBe(17);
-    for (const id of ["pelvis", "chest", "elbow_left", "knee_right", "wrist_left"]) {
+    expect(m.bones.size).toBe(27);
+    for (const id of [
+      "pelvis",
+      "chest",
+      "elbow_left",
+      "knee_right",
+      "wrist_left",
+      "index_right",
+      "thumb_left",
+    ]) {
       expect(m.bones.has(id)).toBe(true);
     }
   });
@@ -91,6 +103,118 @@ describe("hip-hinge coupling", () => {
       .getWorldPosition(new THREE.Vector3());
     const thigh = kneePos.sub(hipPos).normalize();
     expect(thigh.y).toBeLessThan(-0.95); // points almost straight down
+  });
+});
+
+describe("lying & seated poses", () => {
+  it("lays the supine torso horizontal", () => {
+    const spec = poseFor("supine");
+    expect(spec.root?.rotationDeg).toEqual([-90, 0, 0]);
+
+    const m = buildMannequin();
+    const [rx, ry, rz] = spec.root!.rotationDeg!;
+    m.root.rotation.set(rx * DEG, ry * DEG, rz * DEG);
+    m.root.updateMatrixWorld(true);
+
+    // The torso's long axis (chest local +Y) should be ~horizontal when lying.
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(
+      m.bones.get("chest")!.getWorldQuaternion(new THREE.Quaternion()),
+    );
+    expect(Math.abs(up.y)).toBeLessThan(0.1);
+  });
+
+  it("grounds a lying figure with a bounding-box drop", () => {
+    const m = buildMannequin();
+    m.root.rotation.x = poseFor("prone").root!.rotationDeg![0] * DEG;
+    m.root.updateMatrixWorld(true);
+
+    // Mirror groundFigure(): drop so the lowest mesh point rests at y=0.
+    const box = new THREE.Box3().setFromObject(m.root);
+    m.root.position.y -= box.min.y;
+    m.root.updateMatrixWorld(true);
+
+    const grounded = new THREE.Box3().setFromObject(m.root);
+    expect(grounded.min.y).toBeCloseTo(0, 5);
+  });
+});
+
+describe("reach-IK", () => {
+  it("drives a wrist to a world point within the arm's reach", () => {
+    const m = buildMannequin();
+    m.root.updateMatrixWorld(true);
+    const wrist = m.bones.get("wrist_right")!;
+    const shoulder = m.bones.get("shoulder_right")!;
+
+    // A target ~0.47m from the shoulder — inside the ~0.54m arm reach — so the
+    // hand can actually arrive (a body landmark like a knee is out of range from
+    // a neutral stand, which is exactly why touch-toes hinges the torso first).
+    const target = shoulder
+      .getWorldPosition(new THREE.Vector3())
+      .add(new THREE.Vector3(0.3, -0.2, 0.3));
+
+    solveCCD(
+      { joints: [shoulder, m.bones.get("elbow_right")!], effector: wrist, target },
+      20,
+    );
+    m.root.updateMatrixWorld(true);
+    const after = wrist.getWorldPosition(new THREE.Vector3()).distanceTo(target);
+
+    expect(after).toBeLessThan(0.06);
+  });
+});
+
+describe("hand rig", () => {
+  it("curls every finger on `fingers: flex`", () => {
+    const { ir, warnings } = parse(
+      [
+        'movit posture "Fist"',
+        "  rig humanoid",
+        '  step "Close" 1s ease-out:',
+        "    fingers: flex 80",
+        "  repeat 1",
+      ].join("\n"),
+    );
+    expect(warnings).toEqual([]);
+    const tl = buildTimeline(ir!);
+    const m = buildMannequin();
+    tl.sample(1, m.bones); // end of the Close phase
+
+    for (const id of ["index_left", "middle_right", "pinky_left", "thumb_right"]) {
+      const q = m.bones.get(id)!.quaternion;
+      expect(Math.abs(q.x) + Math.abs(q.y) + Math.abs(q.z)).toBeGreaterThan(0.1);
+    }
+  });
+});
+
+describe("props", () => {
+  it("exposes named anchors for declared props", () => {
+    const { anchors, group } = buildProps(["chair", "bar", "wall"]);
+    expect(anchors.has("seat")).toBe(true);
+    expect(anchors.has("bar")).toBe(true);
+    expect(anchors.has("wall")).toBe(true);
+    expect(anchors.get("bar")!.y).toBeGreaterThan(1.5); // overhead
+    expect(group.children.length).toBeGreaterThan(0);
+  });
+
+  it("drives a wrist to a prop anchor with reach-IK", () => {
+    const m = buildMannequin();
+    m.root.updateMatrixWorld(true);
+    const { anchors } = buildProps(["bar"]);
+    const target = anchors.get("bar")!.clone();
+
+    const wrist = m.bones.get("wrist_right")!;
+    solveCCD(
+      {
+        joints: [m.bones.get("shoulder_right")!, m.bones.get("elbow_right")!],
+        effector: wrist,
+        target,
+      },
+      20,
+    );
+    m.root.updateMatrixWorld(true);
+    // The bar sits at the edge of arm reach; the hand should come up close to it.
+    const d = wrist.getWorldPosition(new THREE.Vector3()).distanceTo(target);
+    expect(d).toBeLessThan(0.2);
   });
 });
 

--- a/packages/movit-render/test/render.test.ts
+++ b/packages/movit-render/test/render.test.ts
@@ -55,6 +55,45 @@ describe("timeline", () => {
   });
 });
 
+describe("hip-hinge coupling", () => {
+  const DEADLIFT = [
+    'movit exercise "Hinge"',
+    "  rig humanoid",
+    "  pose start = standing",
+    '  step "Lower" 2s ease-in-out:',
+    "    pelvis: hinge 90",
+    "    ground-lock: feet",
+    "  repeat 2",
+  ].join("\n");
+
+  it("keeps the thighs world-vertical when the pelvis hinges", () => {
+    const { ir } = parse(DEADLIFT);
+    const tl = buildTimeline(ir!);
+    const m = buildMannequin();
+    const root = m.root;
+
+    // Sample the bottom of the hinge (end of the 2s Lower phase).
+    tl.sample(2, m.bones);
+    root.updateMatrixWorld(true);
+
+    // The torso (chest) should have tipped forward toward horizontal: its rest
+    // down-axis (0,-1,0) pitches away from vertical, so |y| collapses toward 0.
+    const chestDir = new THREE.Vector3(0, -1, 0).applyQuaternion(
+      m.bones.get("chest")!.getWorldQuaternion(new THREE.Quaternion()),
+    );
+    expect(Math.abs(chestDir.y)).toBeLessThan(0.4);
+
+    // ...while the thigh (hip → knee) stays essentially vertical, because the
+    // renderer counter-rotates the hips against the pelvis hinge.
+    const hipPos = m.bones.get("hip_left")!.getWorldPosition(new THREE.Vector3());
+    const kneePos = m.bones
+      .get("knee_left")!
+      .getWorldPosition(new THREE.Vector3());
+    const thigh = kneePos.sub(hipPos).normalize();
+    expect(thigh.y).toBeLessThan(-0.95); // points almost straight down
+  });
+});
+
 describe("ccd ik", () => {
   it("brings an effector close to its target", () => {
     const root = new THREE.Object3D();

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -10,6 +10,44 @@ import twist from "../../spec/examples/spinal-twist.movit?raw";
 import chair from "../../spec/examples/chair-pose.movit?raw";
 import sideBend from "../../spec/examples/side-bend.movit?raw";
 
+// Hip-hinge showcases (the v0.1 engine unlock).
+import deadlift from "../../spec/examples/deadlift.movit?raw";
+import bentOverRow from "../../spec/examples/bent-over-row.movit?raw";
+
+// Anatomy / education — single-joint range-of-motion demos.
+import shoulderAbduction from "../../spec/examples/shoulder-abduction-demo.movit?raw";
+import hipFlexion from "../../spec/examples/hip-flexion-demo.movit?raw";
+import spineRotation from "../../spec/examples/spine-rotation-demo.movit?raw";
+import elbowForearm from "../../spec/examples/elbow-flexion-pronation.movit?raw";
+import kneeFlexion from "../../spec/examples/knee-flexion-demo.movit?raw";
+
+// Physiotherapy / rehab.
+import heelRaises from "../../spec/examples/heel-raises.movit?raw";
+import hamstringCurl from "../../spec/examples/standing-hamstring-curl.movit?raw";
+import hipAbduction from "../../spec/examples/hip-abduction.movit?raw";
+import goodMorning from "../../spec/examples/good-morning.movit?raw";
+
+// Desk / workplace wellness.
+import shoulderRolls from "../../spec/examples/shoulder-rolls.movit?raw";
+import neckSideStretch from "../../spec/examples/neck-side-stretch.movit?raw";
+import chestOpener from "../../spec/examples/chest-opener.movit?raw";
+import overheadReach from "../../spec/examples/overhead-reach-reset.movit?raw";
+
+// Sports / martial arts / warm-up.
+import frontKick from "../../spec/examples/front-kick.movit?raw";
+import jabCross from "../../spec/examples/jab-cross.movit?raw";
+import horseStance from "../../spec/examples/horse-stance.movit?raw";
+import bow from "../../spec/examples/bow.movit?raw";
+import armCircles from "../../spec/examples/arm-circles.movit?raw";
+import highKneeMarch from "../../spec/examples/high-knee-march.movit?raw";
+
+// Dance / choreography (flagship domain).
+import demiPlie from "../../spec/examples/demi-plie.movit?raw";
+import releve from "../../spec/examples/releve.movit?raw";
+import tendu from "../../spec/examples/tendu.movit?raw";
+import portDeBras from "../../spec/examples/port-de-bras.movit?raw";
+import dancePhrase from "../../spec/examples/dance-phrase.movit?raw";
+
 export interface Preset {
   id: string;
   label: string;
@@ -20,16 +58,55 @@ export interface Preset {
 
 // Ordered so the first gallery row spans several domains at a glance. The first
 // entry is also the playground default and the landing hero, so it leads with a
-// strong, full-body movement (the squat).
+// strong, full-body movement (the squat); the dance phrase follows as the
+// flagship "communicate the movement in your head" demo.
 export const PRESETS: Preset[] = [
   { id: "squat", label: "Body-weight squat", domain: "Fitness", source: squat },
-  { id: "neck", label: "Neck rotation", domain: "Physiotherapy", source: neck },
-  { id: "posture", label: "Desk posture reset", domain: "Desk & posture", source: posture },
-  { id: "chair", label: "Chair pose", domain: "Yoga", source: chair },
-  { id: "fold", label: "Standing roll-down", domain: "Mobility", source: fold },
-  { id: "twist", label: "Standing spinal twist", domain: "Desk & posture", source: twist },
-  { id: "sidebend", label: "Standing side bend", domain: "Yoga", source: sideBend },
+  { id: "dance-phrase", label: "Dance phrase (8-count)", domain: "Dance", source: dancePhrase },
+  { id: "deadlift", label: "Deadlift (hip hinge)", domain: "Fitness", source: deadlift },
+  { id: "shoulder-abduction", label: "Shoulder abduction (ROM)", domain: "Education", source: shoulderAbduction },
+  { id: "front-kick", label: "Front kick", domain: "Martial arts", source: frontKick },
+  { id: "good-morning", label: "Good morning (hinge)", domain: "Physiotherapy", source: goodMorning },
+  { id: "chest-opener", label: "Chest opener", domain: "Desk & posture", source: chestOpener },
+
+  // --- Education / anatomy: single-joint ROM demos ---
+  { id: "hip-flexion", label: "Hip flexion (ROM)", domain: "Education", source: hipFlexion },
+  { id: "knee-flexion", label: "Knee flexion (ROM)", domain: "Education", source: kneeFlexion },
+  { id: "spine-rotation", label: "Spine rotation (ROM)", domain: "Education", source: spineRotation },
+  { id: "elbow-forearm", label: "Elbow flexion & forearm rotation", domain: "Education", source: elbowForearm },
+
+  // --- Physiotherapy / rehab ---
+  { id: "heel-raises", label: "Heel raises", domain: "Physiotherapy", source: heelRaises },
+  { id: "hamstring-curl", label: "Standing hamstring curl", domain: "Physiotherapy", source: hamstringCurl },
+  { id: "hip-abduction", label: "Standing hip abduction", domain: "Physiotherapy", source: hipAbduction },
   { id: "shoulder", label: "Shoulder flexion (ROM)", domain: "Physiotherapy", source: shoulder },
+  { id: "neck", label: "Neck rotation", domain: "Physiotherapy", source: neck },
+
+  // --- Desk / workplace wellness ---
+  { id: "posture", label: "Desk posture reset", domain: "Desk & posture", source: posture },
+  { id: "twist", label: "Standing spinal twist", domain: "Desk & posture", source: twist },
+  { id: "shoulder-rolls", label: "Shoulder rolls", domain: "Desk & posture", source: shoulderRolls },
+  { id: "neck-side-stretch", label: "Neck side stretch", domain: "Desk & posture", source: neckSideStretch },
+  { id: "overhead-reach", label: "Overhead reach reset", domain: "Desk & posture", source: overheadReach },
+
+  // --- Sports / martial arts / warm-up ---
+  { id: "jab-cross", label: "Jab-cross", domain: "Martial arts", source: jabCross },
+  { id: "horse-stance", label: "Horse stance", domain: "Martial arts", source: horseStance },
+  { id: "bow", label: "Standing bow (hinge)", domain: "Martial arts", source: bow },
+  { id: "arm-circles", label: "Arm circles", domain: "Warm-up", source: armCircles },
+  { id: "high-knee-march", label: "High-knee march", domain: "Warm-up", source: highKneeMarch },
+
+  // --- Dance / choreography (flagship) ---
+  { id: "demi-plie", label: "Demi-plié", domain: "Dance", source: demiPlie },
+  { id: "releve", label: "Relevé", domain: "Dance", source: releve },
+  { id: "tendu", label: "Tendu", domain: "Dance", source: tendu },
+  { id: "port-de-bras", label: "Port de bras", domain: "Dance", source: portDeBras },
+
+  // --- More fitness / mobility / yoga ---
+  { id: "bent-over-row", label: "Bent-over row (hinge)", domain: "Fitness", source: bentOverRow },
   { id: "biceps", label: "Biceps curl", domain: "Fitness", source: biceps },
   { id: "lateral", label: "Lateral raise", domain: "Fitness", source: lateral },
+  { id: "fold", label: "Standing roll-down", domain: "Mobility", source: fold },
+  { id: "chair", label: "Chair pose", domain: "Yoga", source: chair },
+  { id: "sidebend", label: "Standing side bend", domain: "Yoga", source: sideBend },
 ];

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -48,6 +48,29 @@ import tendu from "../../spec/examples/tendu.movit?raw";
 import portDeBras from "../../spec/examples/port-de-bras.movit?raw";
 import dancePhrase from "../../spec/examples/dance-phrase.movit?raw";
 
+// Reach-to-target IK.
+import touchToes from "../../spec/examples/touch-toes.movit?raw";
+import crossBodyReach from "../../spec/examples/cross-body-reach.movit?raw";
+
+// Lying & seated base poses.
+import gluteBridge from "../../spec/examples/glute-bridge.movit?raw";
+import deadBug from "../../spec/examples/dead-bug.movit?raw";
+import cobra from "../../spec/examples/cobra.movit?raw";
+import seatedForwardFold from "../../spec/examples/seated-forward-fold.movit?raw";
+
+// Scene props + contact anchors.
+import sitToStand from "../../spec/examples/chair-sit-to-stand.movit?raw";
+import boxSquat from "../../spec/examples/box-squat.movit?raw";
+import wallSit from "../../spec/examples/wall-sit.movit?raw";
+import deadHang from "../../spec/examples/dead-hang.movit?raw";
+import hangingKneeRaise from "../../spec/examples/hanging-knee-raise.movit?raw";
+
+// Hand / finger rig.
+import makeAFist from "../../spec/examples/make-a-fist.movit?raw";
+import fingerSpell from "../../spec/examples/finger-spell-demo.movit?raw";
+import handWave from "../../spec/examples/hand-wave.movit?raw";
+import pinchGrip from "../../spec/examples/pinch-grip.movit?raw";
+
 export interface Preset {
   id: string;
   label: string;
@@ -109,4 +132,27 @@ export const PRESETS: Preset[] = [
   { id: "fold", label: "Standing roll-down", domain: "Mobility", source: fold },
   { id: "chair", label: "Chair pose", domain: "Yoga", source: chair },
   { id: "sidebend", label: "Standing side bend", domain: "Yoga", source: sideBend },
+
+  // --- Reach-to-target IK ---
+  { id: "touch-toes", label: "Touch your toes", domain: "Mobility", source: touchToes },
+  { id: "cross-body-reach", label: "Cross-body reach", domain: "Physiotherapy", source: crossBodyReach },
+
+  // --- Lying & seated poses ---
+  { id: "glute-bridge", label: "Glute bridge", domain: "Physiotherapy", source: gluteBridge },
+  { id: "dead-bug", label: "Dead bug", domain: "Physiotherapy", source: deadBug },
+  { id: "cobra", label: "Cobra", domain: "Yoga", source: cobra },
+  { id: "seated-forward-fold", label: "Seated forward fold", domain: "Yoga", source: seatedForwardFold },
+
+  // --- Props: chair / wall / bar ---
+  { id: "sit-to-stand", label: "Sit to stand (chair)", domain: "Functional", source: sitToStand },
+  { id: "box-squat", label: "Box squat (chair)", domain: "Fitness", source: boxSquat },
+  { id: "wall-sit", label: "Wall sit (wall)", domain: "Fitness", source: wallSit },
+  { id: "dead-hang", label: "Dead hang (bar)", domain: "Fitness", source: deadHang },
+  { id: "hanging-knee-raise", label: "Hanging knee raise (bar)", domain: "Fitness", source: hangingKneeRaise },
+
+  // --- Hand / finger rig ---
+  { id: "make-a-fist", label: "Make a fist", domain: "Hand therapy", source: makeAFist },
+  { id: "pinch-grip", label: "Pinch grip", domain: "Hand therapy", source: pinchGrip },
+  { id: "finger-spell", label: "Finger-spelling (approx.)", domain: "Sign language", source: fingerSpell },
+  { id: "hand-wave", label: "Hand wave", domain: "Sign language", source: handWave },
 ];

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -23,15 +23,17 @@ Movit is line- and indentation-oriented. Comments start with `#` or `//`.
 document   = header { directive } ;
 header     = "movit" kind STRING ;
 kind       = "exercise" | "stretch" | "posture" ;       (* free-form word *)
-directive  = rig | pose | step | repeat ;
+directive  = rig | prop | pose | step | repeat ;
 rig        = "rig" WORD ;
-pose       = "pose" "start" "=" WORD ;                  (* neutral|standing|plank *)
+prop       = "prop" WORD ;                              (* chair|wall|bar, repeatable *)
+pose       = "pose" "start" "=" WORD ;                  (* neutral|standing|plank|supine|prone|seated *)
 repeat     = "repeat" NUMBER ;
 step       = "step" STRING DURATION easing ":" { child } ;
 easing     = "linear" | "ease-in" | "ease-out" | "ease-in-out" ;
-child      = jointTarget | groundLock | cue ;
+child      = jointTarget | groundLock | reach | cue ;
 jointTarget= joint ":" action [ NUMBER ] ;
 groundLock = "ground-lock" ":" effector { "," effector } ;
+reach      = "reach" ":" effector target ;             (* effector → world target via IK *)
 cue        = "cue" STRING ;
 DURATION   = NUMBER "s" ;                                (* e.g. 2s, 1.5s *)
 ```
@@ -52,9 +54,11 @@ phase, all joint targets apply concurrently.
 | `knees` | `knee_left`, `knee_right` | yes |
 | `ankles` | `ankle_left`, `ankle_right` | yes |
 | axial | `pelvis`, `spine`, `chest`, `neck`, `head` | — |
+| `fingers` (or `fingers_left` / `fingers_right`) | `thumb_*`, `index_*`, `middle_*`, `ring_*`, `pinky_*` | yes |
 
 Plural names move both sides symmetrically (left-side bones mirror the Y and Z
-axes). Use a singular `*_left` / `*_right` name to move one side.
+axes). Use a singular `*_left` / `*_right` name to move one side. Each finger is a
+single curl (`flex`) joint; the thumb also takes `abduct`/`adduct`.
 
 ---
 
@@ -99,6 +103,8 @@ research §5.1 normative tables. Selected ceilings (degrees):
 | knee | 144 | 5 | — | — |
 | ankle | — | — | — | dorsiflex 15 / plantarflex 50 |
 | pelvis | — | — | — | hinge 120 |
+| finger | 100 | 20 | — | — |
+| thumb | 80 | 20 | 50 | adduct 30 |
 | spine | 90 | 30 | 35 | rotate 45 |
 | neck | 50 | 60 | 45 | rotate 80 |
 
@@ -111,17 +117,27 @@ research §5.1 normative tables. Selected ceilings (degrees):
 
 1. **Forward kinematics** — each phase sets joint angles; the renderer slerps
    bone rotations between phases with the phase's easing.
-2. **Ground-lock IK** — effectors listed in `ground-lock` (`hands`, `feet`) are
-   pinned to their planted floor position via Cyclic Coordinate Descent (CCD)
-   so they stay put while the body moves.
-3. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
+2. **Grounding** — the figure is dropped so its lowest point rests on the floor
+   (a bounding-box drop), which grounds standing, plank, and the lying/seated
+   poses alike.
+3. **Ground-lock IK** — effectors listed in `ground-lock` (`hands`, `feet`) are
+   pinned to their planted floor position so they stay put while the body moves.
+4. **Reach-IK** — a `reach:` line drives an effector (`hand_left|hand_right|
+   foot_left|foot_right`) to a world **target** via Cyclic Coordinate Descent
+   (CCD) over the arm/leg chain. A target is a body landmark bone (e.g.
+   `ankle_left`), the keyword `floor`, or a prop anchor (`bar`, `seat`, `wall`).
+5. **Props** — `prop chair|wall|bar` adds a scene object at a fixed default
+   placement; its named anchors become reach targets.
+6. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
    count surfaced to the UI.
 
-**v0.1 IK note:** Three.js's bundled `CCDIKSolver` targets `SkinnedMesh`; the
-Movit mannequin is rigid capsule segments, so Movit implements the same CCD
-algorithm directly over the Object3D bone hierarchy (`movit-render/ik.ts`).
-Reach-IK, two-person/dual-IK, and collision detection are deferred (research
-§5.2, §6.2).
+**Start poses:** `neutral`, `standing`, `plank`, `supine` (face-up), `prone`
+(face-down), `seated` (long-sit on the floor).
+
+**IK note:** Three.js's bundled `CCDIKSolver` targets `SkinnedMesh`; the Movit
+mannequin is rigid capsule segments, so Movit implements CCD directly over the
+Object3D bone hierarchy (`movit-render/ik.ts`) for both ground-lock and reach.
+Two-person/dual-IK and collision detection remain deferred (research §5.2, §6.2).
 
 ---
 

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -71,7 +71,13 @@ where the previous phase left it).
 | `rotate-in` / `rotate-out` | Y (longitudinal) | internal / external rotation |
 | `supinate` / `pronate` | Y | forearm turn |
 | `dorsiflex` / `plantarflex` | X | ankle up / down |
+| `hinge` | X | tip the torso forward over the hips (`pelvis` only) |
 | `hold neutral` | — | keep at rest |
+
+`hinge` is a **hip hinge**: applied to the `pelvis`, it pivots the torso forward
+over the hip line while the legs stay planted and vertical (the renderer
+counter-rotates the hips). Use it — not spinal `flex` — for a flat-back forward
+bend: deadlift, bent-over row, good-morning, or a bow.
 
 **Coordinate convention:** rest pose is standing, arms at sides, facing +Z. The
 renderer's mannequin is built in this same convention so the parser's resolved
@@ -92,6 +98,7 @@ research §5.1 normative tables. Selected ceilings (degrees):
 | hip | 135 | 20 | 45 | — |
 | knee | 144 | 5 | — | — |
 | ankle | — | — | — | dorsiflex 15 / plantarflex 50 |
+| pelvis | — | — | — | hinge 120 |
 | spine | 90 | 30 | 35 | rotate 45 |
 | neck | 50 | 60 | 45 | rotate 80 |
 

--- a/spec/examples/arm-circles.movit
+++ b/spec/examples/arm-circles.movit
@@ -1,0 +1,18 @@
+movit exercise "Arm circles"
+  rig humanoid
+  pose start = standing
+
+  step "Up & forward" 1.2s ease-in-out:
+    shoulders: flex 120
+    cue "Sweep the arms up and forward"
+
+  step "Out to sides" 1.2s ease-in-out:
+    shoulders: flex 0
+    shoulders: abduct 120
+    cue "Open the arms out wide to the sides"
+
+  step "Down & round" 1.2s ease-in-out:
+    shoulders: abduct 0
+    cue "Lower and continue the circle back to the start"
+
+  repeat 6

--- a/spec/examples/bent-over-row.movit
+++ b/spec/examples/bent-over-row.movit
@@ -1,0 +1,26 @@
+movit exercise "Bent-over row"
+  rig humanoid
+  pose start = standing
+
+  step "Set the hinge" 1.6s ease-in-out:
+    pelvis: hinge 80
+    knees: flex 20
+    shoulders: flex 70
+    elbows: flex 10
+    neck: extend 12
+    ground-lock: feet
+    cue "Hinge to a flat back, let the arms hang straight down"
+
+  step "Row" 0.9s ease-out:
+    shoulders: flex 35
+    elbows: flex 95
+    ground-lock: feet
+    cue "Drive the elbows up past the ribs, squeeze the shoulder blades"
+
+  step "Lower" 1s ease-in:
+    shoulders: flex 70
+    elbows: flex 10
+    ground-lock: feet
+    cue "Lower the bar under control, keep the back flat"
+
+  repeat 8

--- a/spec/examples/bow.movit
+++ b/spec/examples/bow.movit
@@ -1,0 +1,19 @@
+movit posture "Standing bow"
+  rig humanoid
+  pose start = standing
+
+  step "Bow" 2s ease-in-out:
+    pelvis: hinge 35
+    neck: flex 15
+    shoulders: extend 5
+    ground-lock: feet
+    cue "Hinge forward from the hips into a respectful bow, back flat"
+
+  step "Rise" 2s ease-out:
+    pelvis: hinge 0
+    neck: flex 0
+    shoulders: extend 0
+    ground-lock: feet
+    cue "Return smoothly to standing"
+
+  repeat 3

--- a/spec/examples/box-squat.movit
+++ b/spec/examples/box-squat.movit
@@ -1,0 +1,24 @@
+movit exercise "Box squat"
+  rig humanoid
+  prop chair
+  pose start = standing
+
+  step "Sit back" 1.6s ease-in-out:
+    hips: flex 85
+    knees: flex 90
+    ankles: dorsiflex 12
+    spine: flex 10
+    shoulders: flex 70
+    ground-lock: feet
+    cue "Push the hips back and sit lightly onto the box"
+
+  step "Stand" 1.4s ease-out:
+    hips: flex 0
+    knees: flex 0
+    ankles: dorsiflex 0
+    spine: flex 0
+    shoulders: flex 0
+    ground-lock: feet
+    cue "Drive up to standing without bouncing off the box"
+
+  repeat 8

--- a/spec/examples/chair-sit-to-stand.movit
+++ b/spec/examples/chair-sit-to-stand.movit
@@ -1,0 +1,24 @@
+movit exercise "Sit to stand"
+  rig humanoid
+  prop chair
+  pose start = standing
+
+  step "Sit" 2s ease-in-out:
+    hips: flex 90
+    knees: flex 95
+    ankles: dorsiflex 14
+    spine: flex 12
+    shoulders: flex 60
+    ground-lock: feet
+    cue "Hinge the hips back and lower with control to sit on the chair"
+
+  step "Stand" 1.8s ease-out:
+    hips: flex 0
+    knees: flex 0
+    ankles: dorsiflex 0
+    spine: flex 0
+    shoulders: flex 0
+    ground-lock: feet
+    cue "Drive through the heels and reach tall to stand"
+
+  repeat 8

--- a/spec/examples/chest-opener.movit
+++ b/spec/examples/chest-opener.movit
@@ -1,0 +1,19 @@
+movit stretch "Chest opener"
+  rig humanoid
+  pose start = standing
+
+  step "Open" 3s ease-in-out:
+    shoulders: extend 40
+    chest: extend 18
+    spine: extend 12
+    ground-lock: feet
+    cue "Reach the arms back and lift the chest — open the front line"
+
+  step "Release" 2.5s ease-in-out:
+    shoulders: extend 0
+    chest: flex 0
+    spine: flex 0
+    ground-lock: feet
+    cue "Return to neutral, ribs stacked over the hips"
+
+  repeat 4

--- a/spec/examples/cobra.movit
+++ b/spec/examples/cobra.movit
@@ -1,0 +1,21 @@
+movit stretch "Cobra"
+  rig humanoid
+  pose start = prone
+
+  step "Lift" 2.5s ease-in-out:
+    spine: extend 25
+    chest: extend 18
+    neck: extend 30
+    shoulders: extend 30
+    elbows: flex 40
+    cue "Press into the hands and lift the chest, rolling the shoulders back"
+
+  step "Lower" 2.5s ease-in-out:
+    spine: flex 0
+    chest: flex 0
+    neck: flex 0
+    shoulders: extend 0
+    elbows: flex 0
+    cue "Lower the chest back to the floor with control"
+
+  repeat 4

--- a/spec/examples/cross-body-reach.movit
+++ b/spec/examples/cross-body-reach.movit
@@ -1,0 +1,27 @@
+movit stretch "Cross-body reach"
+  rig humanoid
+  pose start = standing
+
+  step "Reach across right" 2s ease-in-out:
+    spine: rotate-in 20
+    reach: hand_right knee_left
+    ground-lock: feet
+    cue "Rotate gently and reach the right hand toward the left knee"
+
+  step "Return" 1.4s ease-out:
+    spine: rotate-in 0
+    ground-lock: feet
+    cue "Unwind back to standing tall"
+
+  step "Reach across left" 2s ease-in-out:
+    spine: rotate-out 20
+    reach: hand_left knee_right
+    ground-lock: feet
+    cue "Reach the left hand toward the right knee"
+
+  step "Center" 1.4s ease-out:
+    spine: rotate-out 0
+    ground-lock: feet
+    cue "Return to center"
+
+  repeat 2

--- a/spec/examples/dance-phrase.movit
+++ b/spec/examples/dance-phrase.movit
@@ -1,0 +1,41 @@
+movit exercise "Dance phrase (8-count)"
+  rig humanoid
+  pose start = standing
+
+  step "1-2 - breath, arms to second" 2s ease-in-out:
+    hips: rotate-out 25
+    shoulders: abduct 80
+    elbows: flex 16
+    spine: extend 4
+    ground-lock: feet
+    cue "Turn out, open the arms to second, lift through the crown"
+
+  step "3-4 - demi-plié" 2s ease-in-out:
+    hips: flex 18
+    knees: flex 50
+    ankles: dorsiflex 12
+    shoulders: flex 28
+    elbows: flex 30
+    ground-lock: feet
+    cue "Bend the knees over the toes, arms round down through first"
+
+  step "5-6 - relevé, arms en haut" 2s ease-in-out:
+    hips: flex 0
+    knees: flex 0
+    ankles: plantarflex 28
+    shoulders: flex 155
+    elbows: flex 20
+    spine: extend 5
+    ground-lock: feet
+    cue "Press up to relevé and lift the arms into a frame overhead"
+
+  step "7-8 - close" 2s ease-out:
+    ankles: plantarflex 0
+    hips: rotate-out 0
+    shoulders: flex 0
+    elbows: flex 0
+    spine: flex 0
+    ground-lock: feet
+    cue "Lower the heels and resolve, arms floating back to the sides"
+
+  repeat 2

--- a/spec/examples/dead-bug.movit
+++ b/spec/examples/dead-bug.movit
@@ -1,0 +1,32 @@
+movit exercise "Dead bug"
+  rig humanoid
+  pose start = supine
+
+  step "Set" 1s ease-in-out:
+    shoulders: flex 90
+    hips: flex 90
+    knees: flex 90
+    cue "Arms reach to the ceiling, knees stacked over the hips"
+
+  step "Extend right arm & left leg" 1.2s ease-in-out:
+    shoulder_right: flex 150
+    hip_left: flex 25
+    knee_left: flex 30
+    cue "Lower the right arm overhead and the left leg toward the floor"
+
+  step "Switch" 1.2s ease-in-out:
+    shoulder_right: flex 90
+    hip_left: flex 90
+    knee_left: flex 90
+    shoulder_left: flex 150
+    hip_right: flex 25
+    knee_right: flex 30
+    cue "Return and switch — left arm and right leg reach out"
+
+  step "Return" 1s ease-out:
+    shoulder_left: flex 90
+    hip_right: flex 90
+    knee_right: flex 90
+    cue "Bring everything back to the start position"
+
+  repeat 4

--- a/spec/examples/dead-hang.movit
+++ b/spec/examples/dead-hang.movit
@@ -1,0 +1,16 @@
+movit exercise "Dead hang"
+  rig humanoid
+  prop bar
+  pose start = standing
+
+  step "Hang" 3s ease-in-out:
+    knees: flex 20
+    reach: hand_left bar
+    reach: hand_right bar
+    cue "Reach up, grip the bar, and let the shoulders relax into a long hang"
+
+  step "Down" 1.5s ease-out:
+    knees: flex 0
+    cue "Set the feet down and shake out the arms"
+
+  repeat 3

--- a/spec/examples/deadlift.movit
+++ b/spec/examples/deadlift.movit
@@ -1,0 +1,21 @@
+movit exercise "Deadlift"
+  rig humanoid
+  pose start = standing
+
+  step "Lower" 1.8s ease-in-out:
+    pelvis: hinge 95
+    knees: flex 25
+    shoulders: flex 90
+    neck: extend 12
+    ground-lock: feet
+    cue "Push the hips back and hinge with a flat back — let the arms hang to the bar"
+
+  step "Lift" 1.4s ease-out:
+    pelvis: hinge 0
+    knees: flex 0
+    shoulders: flex 0
+    neck: extend 0
+    ground-lock: feet
+    cue "Drive the hips forward to stand tall, bar close to the body"
+
+  repeat 8

--- a/spec/examples/demi-plie.movit
+++ b/spec/examples/demi-plie.movit
@@ -1,0 +1,27 @@
+movit exercise "Demi-plié"
+  rig humanoid
+  pose start = standing
+
+  step "Plié" 2s ease-in-out:
+    hips: flex 20
+    hips: rotate-out 30
+    knees: flex 55
+    ankles: dorsiflex 12
+    shoulders: abduct 70
+    elbows: flex 15
+    spine: extend 4
+    ground-lock: feet
+    cue "Turn out from the hips and bend the knees over the toes — heels down"
+
+  step "Straighten" 2s ease-out:
+    hips: flex 0
+    hips: rotate-out 0
+    knees: flex 0
+    ankles: dorsiflex 0
+    shoulders: abduct 0
+    elbows: flex 0
+    spine: flex 0
+    ground-lock: feet
+    cue "Press the floor away and rise to a tall first position"
+
+  repeat 4

--- a/spec/examples/elbow-flexion-pronation.movit
+++ b/spec/examples/elbow-flexion-pronation.movit
@@ -1,0 +1,15 @@
+movit stretch "Elbow flexion & forearm rotation (ROM demo)"
+  rig humanoid
+  pose start = standing
+
+  step "Flex & supinate" 2.5s ease-in-out:
+    elbows: flex 140
+    elbows: supinate 80
+    cue "Bend the elbows and turn the palms up — flexion with supination"
+
+  step "Extend & pronate" 2.5s ease-in-out:
+    elbows: flex 10
+    elbows: pronate 80
+    cue "Straighten and turn the palms down — extension with pronation"
+
+  repeat 4

--- a/spec/examples/finger-spell-demo.movit
+++ b/spec/examples/finger-spell-demo.movit
@@ -1,0 +1,33 @@
+movit posture "Finger-spelling (approx.)"
+  rig humanoid
+  pose start = standing
+
+  step "Letter A" 1.5s ease-in-out:
+    index_right: flex 95
+    middle_right: flex 95
+    ring_right: flex 95
+    pinky_right: flex 95
+    thumb_right: flex 0
+    cue "A — fingers curled into a fist, thumb resting alongside"
+
+  step "Letter B" 1.5s ease-in-out:
+    index_right: flex 0
+    middle_right: flex 0
+    ring_right: flex 0
+    pinky_right: flex 0
+    thumb_right: flex 60
+    cue "B — fingers straight and together, thumb across the palm"
+
+  step "Letter I" 1.5s ease-in-out:
+    index_right: flex 95
+    middle_right: flex 95
+    ring_right: flex 95
+    pinky_right: flex 0
+    thumb_right: flex 60
+    cue "I — only the little finger stands up"
+
+  step "Relax" 1.2s ease-out:
+    fingers_right: flex 0
+    cue "Open and relax the hand"
+
+  repeat 2

--- a/spec/examples/front-kick.movit
+++ b/spec/examples/front-kick.movit
@@ -1,0 +1,25 @@
+movit exercise "Front kick"
+  rig humanoid
+  pose start = standing
+
+  step "Chamber" 0.5s ease-in:
+    hip_right: flex 95
+    knee_right: flex 90
+    cue "Drive the right knee up to chamber the kick"
+
+  step "Extend" 0.35s ease-out:
+    hip_right: flex 100
+    knee_right: flex 5
+    cue "Snap the lower leg out — strike with the ball of the foot"
+
+  step "Re-chamber" 0.45s ease-in:
+    hip_right: flex 95
+    knee_right: flex 90
+    cue "Snap the foot back to chamber"
+
+  step "Return" 0.6s ease-out:
+    hip_right: flex 0
+    knee_right: flex 0
+    cue "Set the foot back down to a fighting stance"
+
+  repeat 5

--- a/spec/examples/glute-bridge.movit
+++ b/spec/examples/glute-bridge.movit
@@ -1,0 +1,18 @@
+movit exercise "Glute bridge"
+  rig humanoid
+  pose start = supine
+
+  step "Bridge up" 1.6s ease-out:
+    knees: flex 90
+    hips: extend 15
+    spine: extend 10
+    ground-lock: feet
+    cue "Press through the feet and lift the hips toward the ceiling"
+
+  step "Lower" 1.6s ease-in:
+    hips: extend 0
+    spine: flex 0
+    ground-lock: feet
+    cue "Lower the hips back to the floor, one vertebra at a time"
+
+  repeat 10

--- a/spec/examples/good-morning.movit
+++ b/spec/examples/good-morning.movit
@@ -1,0 +1,23 @@
+movit exercise "Good morning"
+  rig humanoid
+  pose start = standing
+
+  step "Hinge" 2s ease-in-out:
+    pelvis: hinge 80
+    knees: flex 15
+    shoulders: abduct 45
+    elbows: flex 110
+    neck: extend 10
+    ground-lock: feet
+    cue "Hands behind the head, hinge from the hips with a flat back"
+
+  step "Stand" 1.8s ease-out:
+    pelvis: hinge 0
+    knees: flex 0
+    shoulders: abduct 0
+    elbows: flex 0
+    neck: extend 0
+    ground-lock: feet
+    cue "Squeeze the glutes to return to standing tall"
+
+  repeat 8

--- a/spec/examples/hand-wave.movit
+++ b/spec/examples/hand-wave.movit
@@ -1,0 +1,24 @@
+movit posture "Hand wave"
+  rig humanoid
+  pose start = standing
+
+  step "Raise" 0.8s ease-out:
+    shoulder_right: flex 150
+    elbow_right: flex 20
+    fingers_right: flex 0
+    cue "Raise the hand up high, palm open"
+
+  step "Wave out" 0.6s ease-in-out:
+    fingers_right: flex 30
+    cue "Tip the fingers out..."
+
+  step "Wave in" 0.6s ease-in-out:
+    fingers_right: flex 0
+    cue "...and back again — a friendly wave"
+
+  step "Lower" 0.8s ease-in:
+    shoulder_right: flex 0
+    elbow_right: flex 0
+    cue "Lower the arm back to your side"
+
+  repeat 3

--- a/spec/examples/hanging-knee-raise.movit
+++ b/spec/examples/hanging-knee-raise.movit
@@ -1,0 +1,25 @@
+movit exercise "Hanging knee raise"
+  rig humanoid
+  prop bar
+  pose start = standing
+
+  step "Grip" 1.5s ease-in-out:
+    reach: hand_left bar
+    reach: hand_right bar
+    cue "Grip the bar overhead, arms long, body still"
+
+  step "Raise knees" 1.2s ease-out:
+    hips: flex 90
+    knees: flex 90
+    reach: hand_left bar
+    reach: hand_right bar
+    cue "Draw both knees up toward the chest"
+
+  step "Lower" 1.4s ease-in:
+    hips: flex 0
+    knees: flex 0
+    reach: hand_left bar
+    reach: hand_right bar
+    cue "Lower the legs under control, staying gripped"
+
+  repeat 8

--- a/spec/examples/heel-raises.movit
+++ b/spec/examples/heel-raises.movit
@@ -1,0 +1,15 @@
+movit exercise "Heel raises"
+  rig humanoid
+  pose start = standing
+
+  step "Rise" 1.3s ease-out:
+    ankles: plantarflex 35
+    ground-lock: feet
+    cue "Press through the balls of the feet and lift the heels"
+
+  step "Lower" 1.5s ease-in:
+    ankles: plantarflex 0
+    ground-lock: feet
+    cue "Lower the heels under control"
+
+  repeat 12

--- a/spec/examples/high-knee-march.movit
+++ b/spec/examples/high-knee-march.movit
@@ -1,0 +1,26 @@
+movit exercise "High-knee march"
+  rig humanoid
+  pose start = standing
+
+  step "Right knee up" 0.7s ease-in-out:
+    hip_right: flex 90
+    knee_right: flex 90
+    shoulder_left: flex 40
+    cue "Drive the right knee up to hip height, opposite arm swings"
+
+  step "Switch" 0.7s ease-in-out:
+    hip_right: flex 0
+    knee_right: flex 0
+    shoulder_left: flex 0
+    hip_left: flex 90
+    knee_left: flex 90
+    shoulder_right: flex 40
+    cue "Plant and drive the left knee up"
+
+  step "Down" 0.6s ease-out:
+    hip_left: flex 0
+    knee_left: flex 0
+    shoulder_right: flex 0
+    cue "Return to a tall, ready stance"
+
+  repeat 6

--- a/spec/examples/hip-abduction.movit
+++ b/spec/examples/hip-abduction.movit
@@ -1,0 +1,13 @@
+movit exercise "Standing hip abduction"
+  rig humanoid
+  pose start = standing
+
+  step "Lift" 1.6s ease-in-out:
+    hip_right: abduct 40
+    cue "Lift the right leg out to the side, keep the torso tall"
+
+  step "Lower" 1.6s ease-in-out:
+    hip_right: abduct 0
+    cue "Lower the leg back to the midline"
+
+  repeat 10

--- a/spec/examples/hip-flexion-demo.movit
+++ b/spec/examples/hip-flexion-demo.movit
@@ -1,0 +1,13 @@
+movit stretch "Hip flexion (ROM demo)"
+  rig humanoid
+  pose start = standing
+
+  step "Lift" 2.5s ease-in-out:
+    hip_right: flex 90
+    cue "Raise the straight right leg forward — sagittal-plane hip flexion"
+
+  step "Lower" 2.5s ease-in-out:
+    hip_right: flex 0
+    cue "Lower the leg back under the hip"
+
+  repeat 4

--- a/spec/examples/horse-stance.movit
+++ b/spec/examples/horse-stance.movit
@@ -1,0 +1,27 @@
+movit posture "Horse stance"
+  rig humanoid
+  pose start = standing
+
+  step "Sink" 2s ease-in-out:
+    hips: flex 30
+    hips: abduct 25
+    knees: flex 90
+    ankles: dorsiflex 10
+    spine: extend 5
+    shoulders: flex 80
+    elbows: flex 90
+    ground-lock: feet
+    cue "Sink into a wide, low stance — thighs working, back tall, guard up"
+
+  step "Rise" 2s ease-out:
+    hips: flex 0
+    hips: abduct 0
+    knees: flex 0
+    ankles: dorsiflex 0
+    spine: flex 0
+    shoulders: flex 0
+    elbows: flex 0
+    ground-lock: feet
+    cue "Press the floor away and stand tall"
+
+  repeat 4

--- a/spec/examples/jab-cross.movit
+++ b/spec/examples/jab-cross.movit
@@ -1,0 +1,29 @@
+movit exercise "Jab-cross"
+  rig humanoid
+  pose start = standing
+
+  step "Jab" 0.4s ease-out:
+    shoulder_left: flex 85
+    elbow_left: flex 15
+    spine: rotate-out 10
+    cue "Snap the lead (left) hand straight out, rotating slightly into it"
+
+  step "Recoil jab" 0.4s ease-in:
+    shoulder_left: flex 0
+    elbow_left: flex 90
+    spine: rotate-out 0
+    cue "Bring the hand back to guard"
+
+  step "Cross" 0.45s ease-out:
+    shoulder_right: flex 90
+    elbow_right: flex 10
+    spine: rotate-in 35
+    cue "Drive the rear (right) hand across, rotating the trunk"
+
+  step "Recoil cross" 0.45s ease-in:
+    shoulder_right: flex 0
+    elbow_right: flex 90
+    spine: rotate-in 0
+    cue "Return to guard, hands high"
+
+  repeat 4

--- a/spec/examples/knee-flexion-demo.movit
+++ b/spec/examples/knee-flexion-demo.movit
@@ -1,0 +1,13 @@
+movit stretch "Knee flexion (ROM demo)"
+  rig humanoid
+  pose start = standing
+
+  step "Flex" 2.5s ease-in-out:
+    knee_right: flex 130
+    cue "Bend the right knee, heel toward the glutes — the knee's single plane"
+
+  step "Extend" 2.5s ease-in-out:
+    knee_right: flex 0
+    cue "Lower the shin back to standing"
+
+  repeat 4

--- a/spec/examples/make-a-fist.movit
+++ b/spec/examples/make-a-fist.movit
@@ -1,0 +1,13 @@
+movit posture "Make a fist"
+  rig humanoid
+  pose start = standing
+
+  step "Close" 1.2s ease-out:
+    fingers: flex 80
+    cue "Curl the fingers and thumb in to make a closed fist"
+
+  step "Open" 1.2s ease-in:
+    fingers: flex 0
+    cue "Spread the fingers wide open"
+
+  repeat 6

--- a/spec/examples/neck-side-stretch.movit
+++ b/spec/examples/neck-side-stretch.movit
@@ -1,0 +1,20 @@
+movit stretch "Neck side stretch"
+  rig humanoid
+  pose start = standing
+
+  step "Ear to right" 3s ease-in-out:
+    neck: abduct 40
+    ground-lock: feet
+    cue "Gently take the right ear toward the right shoulder"
+
+  step "Ear to left" 3.4s ease-in-out:
+    neck: adduct 40
+    ground-lock: feet
+    cue "Pass through center and lengthen to the left"
+
+  step "Center" 2s ease-out:
+    neck: adduct 0
+    ground-lock: feet
+    cue "Float the head back to neutral"
+
+  repeat 3

--- a/spec/examples/overhead-reach-reset.movit
+++ b/spec/examples/overhead-reach-reset.movit
@@ -1,0 +1,19 @@
+movit stretch "Overhead reach reset"
+  rig humanoid
+  pose start = standing
+
+  step "Reach up" 2.5s ease-in-out:
+    shoulders: flex 175
+    spine: extend 10
+    neck: extend 15
+    ground-lock: feet
+    cue "Reach both arms tall overhead and lengthen the spine"
+
+  step "Lower" 2.5s ease-in-out:
+    shoulders: flex 0
+    spine: flex 0
+    neck: flex 0
+    ground-lock: feet
+    cue "Float the arms down and stack tall"
+
+  repeat 5

--- a/spec/examples/pinch-grip.movit
+++ b/spec/examples/pinch-grip.movit
@@ -1,0 +1,17 @@
+movit posture "Pinch grip"
+  rig humanoid
+  pose start = standing
+
+  step "Pinch" 1.2s ease-out:
+    thumb_right: flex 55
+    thumb_right: adduct 25
+    index_right: flex 60
+    cue "Bring the thumb and index fingertip together in a pinch"
+
+  step "Release" 1.2s ease-in:
+    thumb_right: flex 0
+    thumb_right: adduct 0
+    index_right: flex 0
+    cue "Open the hand and release"
+
+  repeat 6

--- a/spec/examples/port-de-bras.movit
+++ b/spec/examples/port-de-bras.movit
@@ -1,0 +1,33 @@
+movit stretch "Port de bras"
+  rig humanoid
+  pose start = standing
+
+  step "First position" 2s ease-in-out:
+    shoulders: flex 30
+    elbows: flex 35
+    hips: rotate-out 20
+    ground-lock: feet
+    cue "Arms rounded low in front — first position, shoulders soft"
+
+  step "Second position" 2.2s ease-in-out:
+    shoulders: flex 0
+    shoulders: abduct 85
+    elbows: flex 16
+    ground-lock: feet
+    cue "Open the arms out to the sides — second position, wrists lifted"
+
+  step "Fifth en haut" 2.2s ease-in-out:
+    shoulders: abduct 0
+    shoulders: flex 160
+    elbows: flex 20
+    ground-lock: feet
+    cue "Float the arms into a rounded frame overhead — fifth position"
+
+  step "Lower" 2s ease-out:
+    shoulders: flex 0
+    elbows: flex 0
+    hips: rotate-out 0
+    ground-lock: feet
+    cue "Lower through second back to the start, eyes following the hands"
+
+  repeat 3

--- a/spec/examples/releve.movit
+++ b/spec/examples/releve.movit
@@ -1,0 +1,24 @@
+movit exercise "Relevé"
+  rig humanoid
+  pose start = standing
+
+  step "Rise" 1.6s ease-out:
+    ankles: plantarflex 30
+    hips: rotate-out 25
+    knees: extend 0
+    shoulders: abduct 75
+    elbows: flex 12
+    spine: extend 4
+    ground-lock: feet
+    cue "Turn out and rise onto the balls of the feet — lengthen up tall"
+
+  step "Lower" 1.8s ease-in:
+    ankles: plantarflex 0
+    hips: rotate-out 0
+    shoulders: abduct 0
+    elbows: flex 0
+    spine: flex 0
+    ground-lock: feet
+    cue "Lower the heels with control, staying lifted through the spine"
+
+  repeat 5

--- a/spec/examples/seated-forward-fold.movit
+++ b/spec/examples/seated-forward-fold.movit
@@ -1,0 +1,17 @@
+movit stretch "Seated forward fold"
+  rig humanoid
+  pose start = seated
+
+  step "Fold" 3s ease-in-out:
+    pelvis: hinge 70
+    neck: flex 10
+    reach: hand_left ankle_left
+    reach: hand_right ankle_right
+    cue "Hinge forward over the legs and reach toward the feet"
+
+  step "Rise" 2.5s ease-in-out:
+    pelvis: hinge 0
+    neck: flex 0
+    cue "Roll back up to a tall seated spine"
+
+  repeat 3

--- a/spec/examples/shoulder-abduction-demo.movit
+++ b/spec/examples/shoulder-abduction-demo.movit
@@ -1,0 +1,13 @@
+movit stretch "Shoulder abduction (ROM demo)"
+  rig humanoid
+  pose start = standing
+
+  step "Abduct" 2.5s ease-in-out:
+    shoulders: abduct 160
+    cue "Arms sweep out and up to the sides — frontal-plane abduction"
+
+  step "Adduct" 2.5s ease-in-out:
+    shoulders: abduct 0
+    cue "Lower back to the sides through the same arc"
+
+  repeat 4

--- a/spec/examples/shoulder-rolls.movit
+++ b/spec/examples/shoulder-rolls.movit
@@ -1,0 +1,23 @@
+movit stretch "Shoulder rolls"
+  rig humanoid
+  pose start = standing
+
+  step "Lift & forward" 1.6s ease-in-out:
+    shoulders: flex 25
+    chest: extend 8
+    ground-lock: feet
+    cue "Roll the shoulders up and forward"
+
+  step "Back & down" 1.6s ease-in-out:
+    shoulders: extend 20
+    chest: extend 12
+    ground-lock: feet
+    cue "Squeeze the shoulder blades back and down"
+
+  step "Reset" 1.4s ease-out:
+    shoulders: flex 0
+    chest: flex 0
+    ground-lock: feet
+    cue "Return to a tall, neutral posture"
+
+  repeat 5

--- a/spec/examples/spine-rotation-demo.movit
+++ b/spec/examples/spine-rotation-demo.movit
@@ -1,0 +1,20 @@
+movit stretch "Spine rotation (ROM demo)"
+  rig humanoid
+  pose start = standing
+
+  step "Rotate right" 2.5s ease-in-out:
+    spine: rotate-out 45
+    ground-lock: feet
+    cue "Rotate the trunk to the right — transverse-plane spinal rotation"
+
+  step "Rotate left" 2.5s ease-in-out:
+    spine: rotate-in 45
+    ground-lock: feet
+    cue "Pass through center and rotate to the left"
+
+  step "Center" 2s ease-out:
+    spine: rotate-in 0
+    ground-lock: feet
+    cue "Return to a neutral facing"
+
+  repeat 3

--- a/spec/examples/standing-hamstring-curl.movit
+++ b/spec/examples/standing-hamstring-curl.movit
@@ -1,0 +1,13 @@
+movit exercise "Standing hamstring curl"
+  rig humanoid
+  pose start = standing
+
+  step "Curl" 1.4s ease-out:
+    knee_right: flex 95
+    cue "Bend the right knee, drawing the heel toward the glute"
+
+  step "Lower" 1.6s ease-in:
+    knee_right: flex 0
+    cue "Lower the foot back to the floor"
+
+  repeat 10

--- a/spec/examples/tendu.movit
+++ b/spec/examples/tendu.movit
@@ -1,0 +1,22 @@
+movit exercise "Tendu"
+  rig humanoid
+  pose start = standing
+
+  step "Point front" 1.6s ease-in-out:
+    hip_right: flex 22
+    hip_right: rotate-out 30
+    knee_right: extend 0
+    ankle_right: plantarflex 45
+    shoulders: abduct 70
+    elbows: flex 14
+    cue "Brush the right foot forward to a fully pointed tendu, leg turned out"
+
+  step "Close" 1.6s ease-in-out:
+    hip_right: flex 0
+    hip_right: rotate-out 0
+    ankle_right: plantarflex 0
+    shoulders: abduct 0
+    elbows: flex 0
+    cue "Draw the foot back to first position, heel down"
+
+  repeat 4

--- a/spec/examples/touch-toes.movit
+++ b/spec/examples/touch-toes.movit
@@ -1,0 +1,21 @@
+movit stretch "Touch your toes"
+  rig humanoid
+  pose start = standing
+
+  step "Fold" 2.5s ease-in-out:
+    pelvis: hinge 95
+    knees: flex 12
+    neck: flex 15
+    reach: hand_left ankle_left
+    reach: hand_right ankle_right
+    ground-lock: feet
+    cue "Hinge from the hips and reach your hands down toward your ankles"
+
+  step "Rise" 2s ease-out:
+    pelvis: hinge 0
+    knees: flex 0
+    neck: flex 0
+    ground-lock: feet
+    cue "Stack the spine back up to standing tall"
+
+  repeat 3

--- a/spec/examples/wall-sit.movit
+++ b/spec/examples/wall-sit.movit
@@ -1,0 +1,22 @@
+movit posture "Wall sit"
+  rig humanoid
+  prop wall
+  pose start = standing
+
+  step "Slide down" 2.5s ease-in-out:
+    hips: flex 90
+    knees: flex 90
+    ankles: dorsiflex 12
+    shoulders: flex 80
+    ground-lock: feet
+    cue "Slide the back down the wall until the thighs are parallel"
+
+  step "Hold & rise" 2.5s ease-out:
+    hips: flex 0
+    knees: flex 0
+    ankles: dorsiflex 0
+    shoulders: flex 0
+    ground-lock: feet
+    cue "Press through the heels and slide back up the wall"
+
+  repeat 4

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -34,7 +34,11 @@ wrists hips knees ankles`. Plural names move both sides symmetrically; use
 - `flex` / `extend` — bend / straighten (sagittal)
 - `abduct` / `adduct` — away from / toward midline (frontal)
 - `rotate-in` / `rotate-out` — internal / external rotation
+- `supinate` / `pronate` — forearm turn (palm up / down)
 - `dorsiflex` / `plantarflex` — ankle up / down
+- `hinge` — **hip hinge** (on `pelvis` only): tip the torso forward over the
+  hips with a flat back, legs staying planted. Use this — not spinal `flex` —
+  for a deadlift, bent-over row, good-morning, or a bow.
 - `hold neutral` — keep the joint at rest
 
 ## Rules
@@ -71,3 +75,61 @@ movit exercise "Body-weight squat"
 
   repeat 8
 ```
+
+## Hip-hinge example
+
+A flat-back hinge bends at the **hips**, not the spine. Hinge the `pelvis` and
+let the arms hang; `ground-lock: feet`.
+
+```movit
+movit exercise "Deadlift"
+  rig humanoid
+  pose start = standing
+
+  step "Lower" 1.8s ease-in-out:
+    pelvis: hinge 95
+    knees: flex 25
+    shoulders: flex 90
+    ground-lock: feet
+    cue "Hips back, flat back — let the arms hang to the bar"
+
+  step "Lift" 1.4s ease-out:
+    pelvis: hinge 0
+    knees: flex 0
+    shoulders: flex 0
+    ground-lock: feet
+    cue "Drive the hips forward to stand tall"
+
+  repeat 8
+```
+
+## Authoring by domain
+
+The same grammar covers many fields. A few patterns that read well:
+
+- **Anatomy / education** — isolate one joint and sweep it through its range
+  (`shoulders: abduct 160` → `0`). Name the plane in the cue. Great for teaching.
+- **Physiotherapy** — gentle, single-joint reps; for one-sided work use a
+  singular joint (`knee_right: flex 95`) and skip `ground-lock` so the standing
+  leg stays planted.
+- **Desk / posture** — slow `stretch` documents with `ground-lock: feet`;
+  contrast a "collapsed" phase with a "tall" reset.
+- **Sports / martial arts** — short, snappy phases (0.3–0.6s) with `ease-out`
+  on the strike; chamber → extend → re-chamber → return.
+
+### Dance / choreography
+
+Movit shines for **showing the movement in your head**. Build a phrase as a
+sequence of phases, one per count or musical beat, and let later phases inherit
+unset joints:
+
+- **Turnout:** `hips: rotate-out 25–30`.
+- **Port de bras (arm positions):** first `shoulders: flex 30, elbows: flex 35`;
+  second `shoulders: abduct 85, elbows: flex 16`; fifth/en haut
+  `shoulders: flex 160, elbows: flex 20`. Move between them across phases.
+- **Plié:** `hips: flex 18, knees: flex 50, ankles: dorsiflex 12`.
+- **Relevé:** `ankles: plantarflex 28` (rise onto the balls of the feet).
+
+Name each step by its count (`"5-6 - relevé, arms en haut"`) so the phrase reads
+like choreography. To extend a phrase, append more steps — the figure carries
+its pose forward. Use `ground-lock: feet` for grounded phrases.

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -15,9 +15,11 @@ code block — no prose.
 ```
 movit <kind> "<Name>"          # kind = exercise | stretch | posture
   rig humanoid
-  pose start = <pose>          # neutral | standing | plank
+  prop <type>                  # optional: chair | wall | bar (repeatable)
+  pose start = <pose>          # neutral | standing | plank | supine | prone | seated
   step "<Phase name>" <Ns> <easing>:   # easing = linear | ease-in | ease-out | ease-in-out
     <joint>: <action> <degrees>
+    reach: <effector> <target> # optional: drive a hand/foot to a target via IK
     ground-lock: <effectors>   # hands and/or feet pinned to the floor this phase
     cue "<short coaching cue>"
   repeat <count>
@@ -27,7 +29,8 @@ movit <kind> "<Name>"          # kind = exercise | stretch | posture
 
 `neck head spine chest pelvis` and (singular or plural) `shoulders elbows
 wrists hips knees ankles`. Plural names move both sides symmetrically; use
-`elbow_left` etc. for one side.
+`elbow_left` etc. for one side. Fingers: `fingers` (or `fingers_left` /
+`fingers_right`), and individually `thumb_* index_* middle_* ring_* pinky_*`.
 
 ## Actions (degrees are absolute targets)
 
@@ -102,6 +105,33 @@ movit exercise "Deadlift"
 
   repeat 8
 ```
+
+## Reaching, props, lying poses & hands
+
+- **Reach a target** — `reach: <effector> <target>` drives a hand or foot to a
+  world point via IK. Effectors: `hand_left hand_right foot_left foot_right`.
+  Targets: a body landmark bone (`ankle_left`, `knee_right`…), `floor`, or a prop
+  anchor (`bar`, `seat`, `wall`). Author the gross pose (e.g. a `pelvis: hinge`),
+  then let `reach` finish the hand placement. Example — touch your toes:
+
+  ```movit
+  step "Fold" 2.5s ease-in-out:
+    pelvis: hinge 95
+    knees: flex 12
+    reach: hand_left ankle_left
+    reach: hand_right ankle_right
+    ground-lock: feet
+    cue "Hinge and reach toward the ankles"
+  ```
+
+- **Props** — `prop chair | wall | bar` (top level). The chair sits behind the
+  figure (sit-to-stand, box squat), the wall behind that (wall sit), the bar
+  overhead (dead hang, hanging knee raise — `reach: hand_left bar`).
+- **Lying / seated** — `pose start = supine | prone | seated` for floor and mat
+  work (glute bridge, dead bug, cobra, seated forward fold).
+- **Hands** — `fingers: flex 80` makes a fist; curl individual fingers for shapes
+  (`index_right: flex 95`). Single-DOF per finger — good for grip and rough
+  gesture, not exact sign language.
 
 ## Authoring by domain
 


### PR DESCRIPTION
Engine: add a `hinge` action on the pelvis (parser action + pelvis ROM,
max 120°). The renderer counter-rotates the hips against the pelvis tip so
the legs stay planted while the torso pivots over the hip line — a true hip
hinge instead of the faked spinal roll-down. Powers deadlift, bent-over-row,
good-morning, and bow.

Content: 26 new curated .movit examples across Education (single-joint ROM
demos), Physiotherapy, Desk & posture, Sports/Martial arts, and Dance (the
flagship, incl. an 8-count dance-phrase) plus hinge showcases. All render on
the v0.1 rig with zero ROM warnings. Registered in the playground presets
with domain tags so the gallery auto-groups them.

Tests: new examples.test.ts parses every example and asserts zero errors and
zero ROM warnings; hinge parse + ROM-clamp tests; a render test asserting the
hip counter-rotation keeps the thighs vertical under a pelvis hinge.

Docs: new docs/market-research.md (go-to-market + per-domain briefs, Dance as
flagship); SPEC.md and llm-authoring.md document `hinge` and add a
domain/dance authoring guide; ROADMAP marks the hinge unlock shipped.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018WCktDrKYZpJjCb2apbqWp