### PR TITLE
Add front box prop + box step-taps

### DIFF
--- a/docs/coverage-gap.md
+++ b/docs/coverage-gap.md
@@ -51,11 +51,15 @@ Ordered by gap size × how cleanly the engine renders it:
 These ~10 movements roughly **double our chest/core/back coverage** — all on
 today's engine, no new primitives required.
 
-**Deferred (need a front-facing prop we don't have):** `step-up` and
-`triceps-dips`. Our only box/bench prop (the chair) is placed *behind* the figure
-for sit-back moves, so a step-up's lead foot and a dip's hands land in empty space.
-These return once we add a front-placed box / dip-station prop (and anchor-aware
-ground-lock) — a clean roadmap item rather than a forced, low-fidelity render.
+**Front box prop (added):** a `prop box` placed in front of the figure now powers
+`box-step-taps` (the lead foot taps the box top — verified landing on the anchor).
+
+**Still deferred:** a true `step-up` and `triceps-dips`. Beyond prop placement,
+both need the figure's whole body to **translate vertically** (rise onto the box /
+lower into the dip), and the rig has no authorable root-height channel yet — the
+pelvis is fixed and only ground-lock nudges it. So a step-up reads as a step-*tap*
+and a dip can't lower. These return with a root-translation primitive (a `lift` /
+body-height channel) — a clean roadmap item, not a forced low-fidelity render.
 
 ## Metadata gap (drives the catalogue work)
 

--- a/packages/movit-language/src/vocab.ts
+++ b/packages/movit-language/src/vocab.ts
@@ -19,7 +19,7 @@ export const EFFECTORS = ["hands", "feet"];
 
 /** Reach effectors (friendly aliases) and the scene props that supply anchors. */
 export const REACH_EFFECTORS = ["hand_left", "hand_right", "foot_left", "foot_right"];
-export const PROPS = ["chair", "wall", "bar"];
+export const PROPS = ["chair", "wall", "bar", "box"];
 
 /** Top-level directives (excluding the `movit` header keyword). */
 export const TOP_KEYWORDS = ["rig", "prop", "pose", "step", "repeat"];
@@ -31,7 +31,7 @@ export const CHILD_KEYWORDS = ["ground-lock", "reach", "cue"];
 export const KEYWORD_DOCS: Record<string, string> = {
   movit: 'Document header — `movit <kind> "<name>"`.',
   rig: "Selects the rig (currently `humanoid`).",
-  prop: "Adds a scene object — `prop chair | wall | bar`. Supplies reach anchors.",
+  prop: "Adds a scene object — `prop chair | wall | bar | box`. Supplies reach anchors.",
   pose: "Sets the starting pose — `pose start = standing | neutral | plank | supine | prone | seated`.",
   start: "Used in `pose start = <pose>`.",
   step: 'A movement phase — `step "<name>" <Ns> <easing>:`.',

--- a/packages/movit-render/src/props.ts
+++ b/packages/movit-render/src/props.ts
@@ -53,6 +53,15 @@ export function buildProps(types: string[], material?: THREE.Material): PropScen
       wall.position.set(0, 1.3, -0.34);
       group.add(wall);
       anchors.set("wall", new THREE.Vector3(0, 0.9, -0.29));
+    } else if (type === "box") {
+      // A low step/plateau placed IN FRONT of the figure (+Z) — the lead foot
+      // steps forward and up onto it. Top surface at ~0.30 m; `box` anchor sits
+      // on top where the foot lands.
+      const topH = 0.3;
+      const plat = box(0.5, topH, 0.42, mat);
+      plat.position.set(0, topH / 2, 0.32);
+      group.add(plat);
+      anchors.set("box", new THREE.Vector3(0, topH, 0.3));
     }
   }
 

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -83,6 +83,7 @@ import forwardLunge from "../../spec/examples/forward-lunge.movit?raw";
 import calfRaise from "../../spec/examples/single-leg-calf-raise.movit?raw";
 import jumpingJacks from "../../spec/examples/jumping-jacks.movit?raw";
 import quadStretch from "../../spec/examples/standing-quad-stretch.movit?raw";
+import boxStepTaps from "../../spec/examples/box-step-taps.movit?raw";
 
 export type Difficulty = "Beginner" | "Intermediate" | "Advanced";
 
@@ -124,6 +125,7 @@ export const PRESETS: Preset[] = [
   { id: "forward-lunge", label: "Forward lunge", domain: "Fitness", bodyPart: "Upper legs", target: "Quadriceps", equipment: "Body weight", difficulty: "Intermediate", source: forwardLunge },
   { id: "calf-raise", label: "Single-leg calf raise", domain: "Fitness", bodyPart: "Lower legs", target: "Calves", equipment: "Body weight", difficulty: "Intermediate", source: calfRaise },
   { id: "jumping-jacks", label: "Jumping jacks", domain: "Warm-up", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: jumpingJacks },
+  { id: "box-step-taps", label: "Box step taps", domain: "Warm-up", bodyPart: "Upper legs", target: "Hip flexors", equipment: "Box", difficulty: "Beginner", source: boxStepTaps },
   { id: "quad-stretch", label: "Standing quad stretch", domain: "Mobility", bodyPart: "Upper legs", target: "Quadriceps", equipment: "Body weight", difficulty: "Beginner", source: quadStretch },
 
   // --- Education / anatomy: single-joint ROM demos ---

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -126,8 +126,9 @@ research §5.1 normative tables. Selected ceilings (degrees):
    foot_left|foot_right`) to a world **target** via Cyclic Coordinate Descent
    (CCD) over the arm/leg chain. A target is a body landmark bone (e.g.
    `ankle_left`), the keyword `floor`, or a prop anchor (`bar`, `seat`, `wall`).
-5. **Props** — `prop chair|wall|bar` adds a scene object at a fixed default
-   placement; its named anchors become reach targets.
+5. **Props** — `prop chair|wall|bar|box` adds a scene object at a fixed default
+   placement (chair/wall behind, bar overhead, box in front); its named anchors
+   become reach targets.
 6. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
    count surfaced to the UI.
 

--- a/spec/examples/box-step-taps.movit
+++ b/spec/examples/box-step-taps.movit
@@ -1,0 +1,26 @@
+movit exercise "Box step taps"
+  rig humanoid
+  prop box
+  pose start = standing
+
+  step "Right tap" 0.6s ease-out:
+    hip_right: flex 70
+    knee_right: flex 90
+    cue "Tap the right foot lightly on top of the box"
+
+  step "Right down" 0.5s ease-in:
+    hip_right: flex 0
+    knee_right: flex 0
+    cue "Return the right foot to the floor"
+
+  step "Left tap" 0.6s ease-out:
+    hip_left: flex 70
+    knee_left: flex 90
+    cue "Tap the left foot on the box"
+
+  step "Left down" 0.5s ease-in:
+    hip_left: flex 0
+    knee_left: flex 0
+    cue "Back to the floor — keep a light, quick rhythm"
+
+  repeat 6


### PR DESCRIPTION
## Summary

Adds a front-placed scene prop and a verified movement that uses it, and documents a real engine limitation that blocks two other moves.

- **`prop box`** (new) — a low platform placed *in front* of the figure (chair/wall sit behind, bar overhead, box in front), with a `box` top anchor.
- **`box-step-taps`** — alternating foot taps onto the box top. Verified through the real rig: both feet land **0.11 m** from the box-top anchor (i.e. on it).
- **Vocab/SPEC** — register the `box` prop.
- **`docs/coverage-gap.md`** — record why a *true* step-up and triceps dips stay deferred: beyond prop placement, both need the body to **translate vertically** (rise onto the box / lower into the dip), and the rig has no authorable root-height channel yet. Step-up is reframed as step-taps until a `lift` primitive lands.

## Verification

- `npm test` → **136 passing** (every example parses ROM-clean; `box-step-taps` auto-covered).
- `npm run build` (playground) → green.
- Smoke pass: all examples sampled through the real timeline + mannequin with finite bone positions; foot-on-box distance measured directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018WCktDrKYZpJjCb2apbqWp)_