### PR TITLE
Curate the landing page examples section instead of dumping all 65

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -125,8 +125,9 @@
         <p class="eyebrow">See it move</p>
         <h2>One language, many practices</h2>
         <p class="section-sub">
-          From physiotherapy and posture to yoga, mobility, and the gym — each opens
-          in the playground, editable and shareable.
+          From physiotherapy and posture to yoga, dance, and sign language — a taste
+          of the library. Every movement opens in the playground, editable and
+          shareable.
         </p>
       </header>
       <div id="examples-grid" class="examples-grid"></div>

--- a/playground/src/landing.css
+++ b/playground/src/landing.css
@@ -463,6 +463,19 @@ code {
   font-weight: 700;
   color: var(--accent);
 }
+.example-more {
+  border-style: dashed;
+  border-color: var(--border-2);
+  background: transparent;
+  justify-content: center;
+}
+.example-more .example-name {
+  color: var(--accent);
+}
+.example-more:hover {
+  border-style: solid;
+  background: var(--panel);
+}
 
 /* --- How it works ---------------------------------------------------------- */
 .how {

--- a/playground/src/landing.ts
+++ b/playground/src/landing.ts
@@ -45,10 +45,20 @@ if ("requestIdleCallback" in window) {
   window.setTimeout(initHero, 200);
 }
 
-// --- Examples gallery: each card opens the movement in the playground -------
+// --- Examples gallery: a curated taste, not the full 65 ---------------------
+// The full library already has a proper filterable/grouped gallery in the
+// playground itself (domain, body part, equipment, difficulty). Dumping all
+// 65 cards into the landing page turned this section into a long doom-scroll
+// on mobile, so show a handful of visually distinct highlights spanning
+// different domains, then hand off to the real gallery.
+const HIGHLIGHT_IDS = ["dance-phrase", "pull-up", "cobra", "touch-toes", "hand-wave"];
+
 const grid = document.getElementById("examples-grid");
 if (grid) {
-  for (const preset of PRESETS) {
+  const byId = new Map(PRESETS.map((p) => [p.id, p]));
+  for (const id of HIGHLIGHT_IDS) {
+    const preset = byId.get(id);
+    if (!preset) continue;
     const card = document.createElement("a");
     card.className = "example-card";
     card.href = `play.html${buildShareHash(preset.source)}`;
@@ -58,6 +68,16 @@ if (grid) {
       <span class="example-go">Open in playground →</span>`;
     grid.append(card);
   }
+
+  const remaining = PRESETS.length - HIGHLIGHT_IDS.length;
+  const more = document.createElement("a");
+  more.className = "example-card example-more";
+  more.href = "play.html";
+  more.innerHTML = `
+    <span class="example-kind">Full library</span>
+    <span class="example-name">+${remaining} more movements</span>
+    <span class="example-go">Browse &amp; filter by domain →</span>`;
+  grid.append(more);
 }
 
 // --- Copy the LLM authoring prompt ------------------------------------------


### PR DESCRIPTION
## Summary

The "See it move" section on the landing page rendered one card per preset directly onto the page, so it grows in lockstep with the movement library (65 cards today). On mobile that collapses to a single column and becomes a long doom-scroll — not a good first impression on a landing page.

The playground itself already has a proper filterable/grouped gallery (domain, body part, equipment, difficulty in `main.ts`). The landing page doesn't need to duplicate it:

- Show five visually distinct highlights spanning different domains: Dance phrase (Dance), Pull-up (Fitness, bar prop), Cobra (Yoga, lying pose), Touch your toes (Mobility, reach-IK), Hand wave (Sign language, hand rig).
- Hand off to the real gallery with a distinct "+60 more movements" tile, styled as a dashed, accent-colored CTA rather than another movement card, linking straight into the playground.

Result: a clean 3×2 grid on desktop, a single column of 6 short cards on mobile instead of 65 — same card styling and colors throughout, just curated.

**Note:** this commit was originally pushed as a follow-up on the `claude/market-research-expansion-3xwm6w` branch after PR #5 (the animation-audit fixes) had already been merged, so it never made it into `main` and only showed up on the branch's own Vercel preview deployment — not production. This PR rebases that commit onto the current `main` so it can be merged properly.

## Test plan

- [x] `npm test` — 139/139 tests pass.
- [x] `npm run build` — production build succeeds.
- [x] Verified with real Playwright screenshots at mobile (390px) and desktop (1440px) viewports that the grid renders as a clean 3×2 (desktop) / 1×6 (mobile) layout.
- [x] Verified all 5 highlight cards deep-link to the correct movement via the share-hash codec, and the "+60 more" tile correctly opens the playground's full filterable gallery (65 presets).


---
_Generated by [Claude Code](https://claude.ai/code/session_018WCktDrKYZpJjCb2apbqWp)_