### PR TITLE
Spatial choreography, abduction fix, rig readability, motion aliveness & clip export

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ domain needs — so contributions land where they unlock the most.
 | **Fitness / strength** | Body-weight and free-form movement coaching | ✅ Core today (squat, curl, raise). Barbell/dumbbell/machine work needs props + grip. |
 | **Functional / elderly care** | Sit-to-stand, balance, gentle ROM, fall-prevention drills | 🟡 Partial — sit-to-stand works; reaching/balance need reach-IK + props. |
 | **Sports technique** | Golf swing, tennis serve, throwing, kicking | 🟡 Partial — needs trunk rotation fidelity, weight shift, and implements (club/racket/ball). |
-| **Dance / choreography** | Notating sequences, port de bras, simple phrases | 🟡 Simple gestures work; precise reach + partner work are future. |
+| **Dance / choreography** | Notating sequences, port de bras, phrases that turn & travel | ✅ Phrases, port de bras, pirouettes, and traveling combos (box-step, grapevine, chassé) work via `turn`/`travel`; partner work is future. |
 | **Martial arts** | Stances, strikes, basic forms | 🟡 Stances/strikes partly work; contact and weapons are future. |
 | **Sign language / gesture** | Finger-spelling, signs, expressive gesture | ⛔ Needs a hand/finger rig (the rig currently ends at the wrist). |
 
@@ -43,7 +43,14 @@ These are the unlocks, roughly in order of leverage:
 5. ~~**Hand / finger articulation**~~ — ✅ **shipped (single-DOF).** Per-finger
    curl bones + `fingers` group. Powers `make-a-fist`, `pinch-grip`, `hand-wave`,
    `finger-spell-demo`. Next: multi-joint fingers for accurate sign language.
-6. **Two-person + collision** — partner stretches, assisted rehab, contact sports
+6. ~~**Spatial choreography (turn & travel)**~~ — ✅ **shipped.** `turn: <deg>`
+   rotates the figure's facing and `travel: <x> <z>` moves it across the floor,
+   both absolute + carried across phases and returning home on the loop wrap.
+   Powers `pirouette`, `box-step`, `grapevine`, `waltz-box`, `chasse`,
+   `walk-cycle`, `quarter-turns` — pirouettes, traveling combos, and gait.
+   Standing poses only. Next: footstep-locked travel (true gait), motion
+   aliveness (velocity-continuous flow + weight shift).
+7. **Two-person + collision** — partner stretches, assisted rehab, contact sports
    (still deferred in the spec).
 
 ## Prop / equipment library (future)

--- a/packages/movit-language/src/vocab.ts
+++ b/packages/movit-language/src/vocab.ts
@@ -25,7 +25,7 @@ export const PROPS = ["chair", "wall", "bar", "box"];
 export const TOP_KEYWORDS = ["rig", "prop", "pose", "step", "repeat"];
 
 /** Keywords valid as step children. */
-export const CHILD_KEYWORDS = ["ground-lock", "reach", "pin", "cue"];
+export const CHILD_KEYWORDS = ["ground-lock", "reach", "pin", "turn", "travel", "cue"];
 
 /** Short docs surfaced on hover and as completion detail. */
 export const KEYWORD_DOCS: Record<string, string> = {
@@ -39,6 +39,8 @@ export const KEYWORD_DOCS: Record<string, string> = {
   "ground-lock": "Pins effectors (hands / feet) to the floor for this phase.",
   reach: "Drives an effector to a target via IK — `reach: hand_left ankle_left`.",
   pin: "Moves the body so an effector sits on an anchor — `pin: hand_left bar` (hang, pull up, step up, dip).",
+  turn: "Turns the figure to face a new direction — `turn: 360` (degrees, yaw about vertical). Absolute, carried across phases. Standing poses only.",
+  travel: "Moves the figure across the floor — `travel: 0.4 0` (world x z metres from the start spot). Absolute, carried across phases. Standing poses only.",
   cue: "A short coaching cue shown while this phase plays.",
   hold: "Keep the joint at its neutral / rest angle.",
 };

--- a/packages/movit-parser/src/clamp.ts
+++ b/packages/movit-parser/src/clamp.ts
@@ -114,6 +114,15 @@ function resolveStep(
     euler,
   }));
 
+  // Travel is clamped to a sane studio footprint (±TRAVEL_MAX m) so a stray
+  // large value can't fling the figure off the ground plane / out of frame.
+  const travel = step.travel
+    ? {
+        x: clampNum(step.travel.x, -TRAVEL_MAX, TRAVEL_MAX),
+        z: clampNum(step.travel.z, -TRAVEL_MAX, TRAVEL_MAX),
+      }
+    : undefined;
+
   return {
     name: step.name,
     durationSec: step.durationSec,
@@ -122,8 +131,17 @@ function resolveStep(
     groundLock: step.groundLock,
     reaches: step.reaches,
     pins: step.pins,
+    ...(step.turn !== undefined ? { turnDeg: step.turn } : {}),
+    ...(travel ? { travel } : {}),
     ...(step.cue ? { cue: step.cue } : {}),
   };
+}
+
+/** Max travel offset from the load spot, metres, in any single axis. */
+const TRAVEL_MAX = 3;
+
+function clampNum(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v));
 }
 
 function ensure(map: Map<string, EulerDeg>, bone: string): EulerDeg {

--- a/packages/movit-parser/src/parser.ts
+++ b/packages/movit-parser/src/parser.ts
@@ -34,6 +34,10 @@ export interface AstStep {
   groundLock: string[];
   reaches: AstReach[];
   pins: AstPin[];
+  /** Root facing (yaw about world Y, degrees) at the end of this phase. */
+  turn?: number;
+  /** Root ground position (world X/Z metres) at the end of this phase. */
+  travel?: { x: number; z: number };
   cue?: string;
   line: number;
 }
@@ -221,6 +225,28 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
       return { line: ln.line, message: "expected `pin: <effector> <anchor>`" };
     }
     current.pins.push({ effector, anchor });
+    return null;
+  }
+
+  if (head === "turn") {
+    // `turn: <degrees>` — the figure's facing (root yaw about world Y) at the
+    // end of this phase. Absolute, accumulated forward like a joint target.
+    if (!current) return { line: ln.line, message: "`turn` outside of a step" };
+    if (t[1]?.type !== "colon" || t[2]?.type !== "num") {
+      return { line: ln.line, message: "expected `turn: <degrees>`" };
+    }
+    current.turn = Number(t[2].value);
+    return null;
+  }
+
+  if (head === "travel") {
+    // `travel: <x> <z>` — the figure's ground position (world X/Z metres) at the
+    // end of this phase. Absolute offset from the load spot, accumulated forward.
+    if (!current) return { line: ln.line, message: "`travel` outside of a step" };
+    if (t[1]?.type !== "colon" || t[2]?.type !== "num" || t[3]?.type !== "num") {
+      return { line: ln.line, message: "expected `travel: <x> <z>`" };
+    }
+    current.travel = { x: Number(t[2].value), z: Number(t[3].value) };
     return null;
   }
 

--- a/packages/movit-parser/src/schema.ts
+++ b/packages/movit-parser/src/schema.ts
@@ -38,6 +38,8 @@ const stepSchema = z.object({
   groundLock: z.array(z.string()),
   reaches: z.array(reachSchema),
   pins: z.array(pinSchema),
+  turn: z.number().optional(),
+  travel: z.object({ x: z.number(), z: z.number() }).optional(),
   cue: z.string().optional(),
   line: z.number(),
 });

--- a/packages/movit-parser/src/types.ts
+++ b/packages/movit-parser/src/types.ts
@@ -59,6 +59,16 @@ export interface Phase {
   reaches: ReachTarget[];
   /** Contact pins active during this phase (translate the body to the anchor). */
   pins: PinTarget[];
+  /**
+   * Root facing (yaw about world Y, degrees) at the end of this phase — an
+   * absolute target carried forward across phases. Powers turns / pirouettes.
+   */
+  turnDeg?: number;
+  /**
+   * Root ground position (world X/Z metres, offset from the load spot) at the
+   * end of this phase — absolute, carried forward. Powers travel / locomotion.
+   */
+  travel?: { x: number; z: number };
   cue?: string;
 }
 

--- a/packages/movit-parser/test/parse.test.ts
+++ b/packages/movit-parser/test/parse.test.ts
@@ -124,4 +124,45 @@ describe("parse", () => {
     const { errors } = parse(src);
     expect(errors.some((e) => /easing/i.test(e.message))).toBe(true);
   });
+
+  it("parses turn and travel into the phase IR", () => {
+    const src = [
+      'movit exercise "Spin & step"',
+      "  rig humanoid",
+      "  pose start = standing",
+      '  step "Spin" 1s ease-in-out:',
+      "    turn: 360",
+      "    travel: -0.4 0.5",
+      "    ground-lock: feet",
+      "  repeat 2",
+    ].join("\n");
+    const { ir, errors, warnings } = parse(src);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    const phase = ir!.phases[0]!;
+    expect(phase.turnDeg).toBe(360);
+    expect(phase.travel).toEqual({ x: -0.4, z: 0.5 });
+  });
+
+  it("clamps travel to the studio footprint", () => {
+    const src = [
+      'movit exercise "Runaway"',
+      "  rig humanoid",
+      '  step "Go" 1s linear:',
+      "    travel: 99 -99",
+    ].join("\n");
+    const { ir } = parse(src);
+    expect(ir!.phases[0]!.travel).toEqual({ x: 3, z: -3 });
+  });
+
+  it("errors on malformed turn/travel", () => {
+    const src = [
+      'movit exercise "Bad"',
+      "  rig humanoid",
+      '  step "Go" 1s linear:',
+      "    travel: 0.4",
+    ].join("\n");
+    const { errors } = parse(src);
+    expect(errors.some((e) => /travel/i.test(e.message))).toBe(true);
+  });
 });

--- a/packages/movit-render/src/index.ts
+++ b/packages/movit-render/src/index.ts
@@ -217,6 +217,9 @@ export function createViewer(
   }
 
   const ROOT_X = new THREE.Vector3(1, 0, 0);
+  // Reused scratch for the per-frame facing rotation (yaw about world Y).
+  const WORLD_Y = new THREE.Vector3(0, 1, 0);
+  const YAW_Q = new THREE.Quaternion();
 
   /** Rotate the whole figure about a world-space pivot (axis through pivot). */
   function rotateRootAboutPivot(pivot: THREE.Vector3, angle: number): void {
@@ -385,8 +388,11 @@ export function createViewer(
     const center = box.getCenter(new THREE.Vector3());
     const size = box.getSize(new THREE.Vector3());
     // Frame against a ~1.8m standing height floor so short poses (squat,
-    // plank) don't zoom in awkwardly; fill most of the viewport.
-    const radius = Math.max(size.x, size.y, size.z, 1.8) * 0.5;
+    // plank) don't zoom in awkwardly; fill most of the viewport. Traveling
+    // movements (turn/travel) roam across the floor, so widen the frame by the
+    // movement's travel extent to keep the figure in view the whole loop.
+    const travel = timeline?.travelExtent ?? 0;
+    const radius = Math.max(size.x, size.y, size.z, 1.8) * 0.5 + travel;
     const dist = (radius / Math.sin((camera.fov * DEG) / 2)) * 1.15 + 0.3;
 
     desiredTarget.copy(center);
@@ -405,6 +411,17 @@ export function createViewer(
       // Recompute root contact from the grounded base each frame (no drift).
       mannequin.root.position.copy(baseRootPos);
       mannequin.root.quaternion.copy(baseRootQuat);
+      // Spatial choreography: layer the phase's facing (yaw about world Y) and
+      // ground travel (world X/Z) onto the base root BEFORE ground-lock. The
+      // feet-only ground-lock only corrects the root's Y, so it composes with
+      // travel (X/Z) and yaw without fighting them; the figure turns and steps
+      // across the floor while its feet still rest on it.
+      if (info.rootYaw !== 0) {
+        YAW_Q.setFromAxisAngle(WORLD_Y, info.rootYaw);
+        mannequin.root.quaternion.premultiply(YAW_Q);
+      }
+      mannequin.root.position.x += info.rootOffset.x;
+      mannequin.root.position.z += info.rootOffset.z;
       mannequin.root.updateMatrixWorld(true);
       applyGroundLock(info.groundLock);
       applyPins(info.pins);

--- a/packages/movit-render/src/timeline.ts
+++ b/packages/movit-render/src/timeline.ts
@@ -25,6 +25,10 @@ interface Keyframe {
   groundLock: string[];
   reaches: ReachTarget[];
   pins: PinTarget[];
+  /** Root facing (yaw about world Y, radians) at this keyframe. */
+  yaw: number;
+  /** Root ground offset (world X/Z metres) from the load spot at this keyframe. */
+  pos: { x: number; z: number };
 }
 
 /** A phase as a time span on the timeline, for scrubber markers / ribbon. */
@@ -52,7 +56,13 @@ export interface BuiltTimeline {
     groundLock: string[];
     reaches: ReachTarget[];
     pins: PinTarget[];
+    /** Interpolated root facing (yaw about world Y, radians). */
+    rootYaw: number;
+    /** Interpolated root ground offset (world X/Z metres) from the load spot. */
+    rootOffset: { x: number; z: number };
   };
+  /** Largest travel offset magnitude reached (metres) — for camera framing. */
+  travelExtent: number;
 }
 
 function eulerToQuat([x, y, z]: EulerDegTuple): THREE.Quaternion {
@@ -76,6 +86,11 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
 
   // Accumulating current joint angles (degrees).
   const curr = new Map<string, EulerDegTuple>(baseJoints);
+  // Accumulating root facing (yaw, degrees) and ground offset (metres), both
+  // carried forward across phases like joints and seeded at home (0).
+  let currYaw = 0;
+  let currPos = { x: 0, z: 0 };
+  let travelExtent = 0;
 
   const keyframes: Keyframe[] = [];
   keyframes.push({
@@ -86,6 +101,8 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     groundLock: [],
     reaches: [],
     pins: [],
+    yaw: 0,
+    pos: { x: 0, z: 0 },
   });
 
   let t = 0;
@@ -93,6 +110,9 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     for (const target of phase.targets) {
       curr.set(target.boneId, [target.euler.x, target.euler.y, target.euler.z]);
     }
+    if (phase.turnDeg !== undefined) currYaw = phase.turnDeg;
+    if (phase.travel) currPos = { x: phase.travel.x, z: phase.travel.z };
+    travelExtent = Math.max(travelExtent, Math.hypot(currPos.x, currPos.z));
     t += phase.durationSec;
     keyframes.push({
       time: t,
@@ -103,11 +123,18 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
       groundLock: phase.groundLock,
       reaches: phase.reaches,
       pins: phase.pins,
+      yaw: currYaw * DEG,
+      pos: { ...currPos },
     });
   }
 
-  // Wrap back to the base pose for a seamless loop.
+  // Wrap back to the base pose (and home position) for a seamless loop. Facing
+  // wraps to the NEAREST FULL TURN to the final yaw, not to 0: a completed 360°
+  // pirouette then holds its facing through the reset and the loop boundary
+  // (360°≡0°) is seamless, instead of visibly un-spinning backward. A partial
+  // turn (e.g. 90°) rounds to 0 and rotates back to front during the reset.
   const wrap = ir.phases[0]?.durationSec ?? 1;
+  const wrapYaw = Math.round(currYaw / 360) * 360 * DEG;
   t += wrap;
   keyframes.push({
     time: t,
@@ -117,6 +144,8 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     groundLock: [],
     reaches: [],
     pins: [],
+    yaw: wrapYaw,
+    pos: { x: 0, z: 0 },
   });
 
   // Fill every keyframe with the full bone set (missing → identity).
@@ -147,6 +176,7 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
     basePose,
     bonesUsed,
     segments,
+    travelExtent,
     sample(time, bones) {
       const tt = duration > 0 ? ((time % duration) + duration) % duration : 0;
       let a = keyframes[0]!;
@@ -167,12 +197,22 @@ export function buildTimeline(ir: MovitIR): BuiltTimeline {
         if (!node) continue;
         node.quaternion.slerpQuaternions(a.quats.get(bone)!, b.quats.get(bone)!, eased);
       }
+      // Root facing/position: linear interpolation of the raw values so a large
+      // turn (e.g. 360°) sweeps the whole way round rather than taking a short
+      // arc. Uses the same eased param as the joints so everything moves as one.
+      const rootYaw = a.yaw + (b.yaw - a.yaw) * eased;
+      const rootOffset = {
+        x: a.pos.x + (b.pos.x - a.pos.x) * eased,
+        z: a.pos.z + (b.pos.z - a.pos.z) * eased,
+      };
       return {
         phaseName: b.name,
         ...(b.cue ? { cue: b.cue } : {}),
         groundLock: b.groundLock,
         reaches: b.reaches,
         pins: b.pins,
+        rootYaw,
+        rootOffset,
       };
     },
   };

--- a/packages/movit-render/test/render.test.ts
+++ b/packages/movit-render/test/render.test.ts
@@ -106,6 +106,65 @@ describe("hip-hinge coupling", () => {
   });
 });
 
+describe("spatial choreography (turn & travel)", () => {
+  it("interpolates root yaw across a turn phase", () => {
+    const src = [
+      'movit exercise "Half turn"',
+      "  rig humanoid",
+      "  pose start = standing",
+      '  step "Spin" 1s linear:',
+      "    turn: 180",
+      "    ground-lock: feet",
+      "  repeat 1",
+    ].join("\n");
+    const { ir } = parse(src);
+    const tl = buildTimeline(ir!);
+    const m = buildMannequin();
+
+    // Midway through the 1s spin → ~90°; at the end → 180° (π radians).
+    expect(tl.sample(0.5, m.bones).rootYaw).toBeCloseTo(Math.PI / 2, 3);
+    expect(tl.sample(1, m.bones).rootYaw).toBeCloseTo(Math.PI, 3);
+  });
+
+  it("interpolates the root ground offset across a travel phase", () => {
+    const src = [
+      'movit exercise "Step over"',
+      "  rig humanoid",
+      "  pose start = standing",
+      '  step "Go" 1s linear:',
+      "    travel: 0.5 -0.4",
+      "    ground-lock: feet",
+      "  repeat 1",
+    ].join("\n");
+    const { ir } = parse(src);
+    const tl = buildTimeline(ir!);
+    const m = buildMannequin();
+
+    const end = tl.sample(1, m.bones).rootOffset;
+    expect(end.x).toBeCloseTo(0.5, 3);
+    expect(end.z).toBeCloseTo(-0.4, 3);
+    // Travel extent (for camera framing) is the largest offset magnitude.
+    expect(tl.travelExtent).toBeCloseTo(Math.hypot(0.5, 0.4), 3);
+  });
+
+  it("leaves yaw and offset at home for movements that never turn/travel", () => {
+    const src = [
+      'movit exercise "Curl"',
+      "  rig humanoid",
+      '  step "Up" 1s linear:',
+      "    elbows: flex 90",
+      "  repeat 1",
+    ].join("\n");
+    const { ir } = parse(src);
+    const tl = buildTimeline(ir!);
+    const m = buildMannequin();
+    const info = tl.sample(1, m.bones);
+    expect(info.rootYaw).toBe(0);
+    expect(info.rootOffset).toEqual({ x: 0, z: 0 });
+    expect(tl.travelExtent).toBe(0);
+  });
+});
+
 describe("lying & seated poses", () => {
   it("lays the supine torso horizontal", () => {
     const spec = poseFor("supine");

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -89,6 +89,15 @@ import pullUp from "../../spec/examples/pull-up.movit?raw";
 import stepUp from "../../spec/examples/step-up.movit?raw";
 import tricepsDips from "../../spec/examples/triceps-dips.movit?raw";
 
+// Spatial choreography (turn & travel) — the figure turns and moves across the floor.
+import pirouette from "../../spec/examples/pirouette.movit?raw";
+import boxStep from "../../spec/examples/box-step.movit?raw";
+import grapevine from "../../spec/examples/grapevine.movit?raw";
+import waltzBox from "../../spec/examples/waltz-box.movit?raw";
+import chasse from "../../spec/examples/chasse.movit?raw";
+import walkCycle from "../../spec/examples/walk-cycle.movit?raw";
+import quarterTurns from "../../spec/examples/quarter-turns.movit?raw";
+
 export type Difficulty = "Beginner" | "Intermediate" | "Advanced";
 
 export interface Preset {
@@ -197,4 +206,11 @@ export const PRESETS: Preset[] = [
   { id: "pinch-grip", label: "Pinch grip", domain: "Hand therapy", bodyPart: "Hands", target: "Forearms", equipment: "Body weight", difficulty: "Beginner", source: pinchGrip },
   { id: "finger-spell", label: "Finger-spelling (approx.)", domain: "Sign language", bodyPart: "Hands", target: "Forearms", equipment: "Body weight", difficulty: "Beginner", source: fingerSpell },
   { id: "hand-wave", label: "Hand wave", domain: "Sign language", bodyPart: "Hands", target: "Forearms", equipment: "Body weight", difficulty: "Beginner", source: handWave },
+  { id: "pirouette", label: "Pirouette (full turn)", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Intermediate", source: pirouette },
+  { id: "box-step", label: "Box step (travels)", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: boxStep },
+  { id: "grapevine", label: "Grapevine (travels)", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: grapevine },
+  { id: "waltz-box", label: "Waltz box step", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: waltzBox },
+  { id: "chasse", label: "Chassé (travels)", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Intermediate", source: chasse },
+  { id: "walk-cycle", label: "Walk & turn", domain: "Locomotion", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: walkCycle },
+  { id: "quarter-turns", label: "Quarter turns", domain: "Locomotion", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Beginner", source: quarterTurns },
 ];

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -30,11 +30,13 @@ pose       = "pose" "start" "=" WORD ;                  (* neutral|standing|plan
 repeat     = "repeat" NUMBER ;
 step       = "step" STRING DURATION easing ":" { child } ;
 easing     = "linear" | "ease-in" | "ease-out" | "ease-in-out" ;
-child      = jointTarget | groundLock | reach | pin | cue ;
+child      = jointTarget | groundLock | reach | pin | turn | travel | cue ;
 jointTarget= joint ":" action [ NUMBER ] ;
 groundLock = "ground-lock" ":" effector { "," effector } ;
 reach      = "reach" ":" effector target ;             (* effector → world target via IK *)
 pin        = "pin" ":" effector anchor ;               (* move the BODY so effector sits on anchor *)
+turn       = "turn" ":" NUMBER ;                       (* face this yaw (deg) by phase end *)
+travel     = "travel" ":" NUMBER NUMBER ;              (* move to this x z (metres) by phase end *)
 cue        = "cue" STRING ;
 DURATION   = NUMBER "s" ;                                (* e.g. 2s, 1.5s *)
 ```
@@ -135,7 +137,15 @@ research §5.1 normative tables. Selected ceilings (degrees):
    reach moves a limb to a target, a **pin moves the body** while the contact
    stays put — so the figure hangs from a bar, pulls up toward it, rises onto a
    box, or lowers into a dip as the joints work.
-6. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
+7. **Spatial choreography** — `turn: <deg>` rotates the figure's facing (yaw
+   about vertical) and `travel: <x> <z>` moves it across the floor (world metres
+   from the load spot). Both are **absolute targets carried across phases** (like
+   joint angles) and both return home on the loop wrap, so a box-step traces a
+   square back to start and a pirouette spins a full turn. They layer under
+   grounding (feet still rest on the floor) and power pirouettes, grapevines,
+   traveling combos, and walk cycles. **Standing poses only** — combining with
+   lying/seated bases (whose root is already tilted) is out of scope.
+8. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
    count surfaced to the UI.
 
 **Start poses:** `neutral`, `standing`, `plank`, `supine` (face-up), `prone`

--- a/spec/examples/box-step.movit
+++ b/spec/examples/box-step.movit
@@ -1,0 +1,39 @@
+movit exercise "Box step"
+  rig humanoid
+  pose start = standing
+
+  step "Step forward-right" 0.9s ease-in-out:
+    hip_right: flex 35
+    knee_right: flex 40
+    shoulder_left: flex 25
+    shoulder_right: extend 15
+    travel: -0.35 0.35
+    ground-lock: feet
+    cue "Step the right foot forward and out to the corner"
+
+  step "Close the feet" 0.7s ease-in-out:
+    hip_right: flex 0
+    knee_right: flex 0
+    shoulders: flex 0
+    travel: -0.35 0.35
+    ground-lock: feet
+    cue "Bring the left foot to meet it, standing tall on the corner"
+
+  step "Step back-left" 0.9s ease-in-out:
+    hip_left: flex 35
+    knee_left: flex 40
+    shoulder_right: flex 25
+    shoulder_left: extend 15
+    travel: 0 0
+    ground-lock: feet
+    cue "Step the left foot back to the start on the diagonal"
+
+  step "Close home" 0.7s ease-in-out:
+    hip_left: flex 0
+    knee_left: flex 0
+    shoulders: flex 0
+    travel: 0 0
+    ground-lock: feet
+    cue "Close the feet together, back home and ready to repeat"
+
+  repeat 4

--- a/spec/examples/chasse.movit
+++ b/spec/examples/chasse.movit
@@ -1,0 +1,41 @@
+movit exercise "Chassé"
+  rig humanoid
+  pose start = standing
+
+  step "Reach & push" 0.8s ease-out:
+    hip_right: flex 30
+    knee_right: flex 25
+    ankle_left: plantarflex 20
+    shoulders: abduct 60
+    elbows: flex 18
+    travel: 0.5 0
+    ground-lock: feet
+    cue "Reach the lead foot out and push off to travel sideways"
+
+  step "Gallop close" 0.6s ease-in:
+    hip_right: flex 0
+    knee_right: flex 0
+    ankle_left: plantarflex 0
+    travel: 0.9 0
+    ground-lock: feet
+    cue "Chase the trailing foot to the lead — feet meet in the air"
+
+  step "Reach & push back" 0.8s ease-out:
+    hip_left: flex 30
+    knee_left: flex 25
+    ankle_right: plantarflex 20
+    travel: 0.4 0
+    ground-lock: feet
+    cue "Change direction and travel back the other way"
+
+  step "Gallop home" 0.6s ease-in:
+    hip_left: flex 0
+    knee_left: flex 0
+    ankle_right: plantarflex 0
+    shoulders: abduct 0
+    elbows: flex 0
+    travel: 0 0
+    ground-lock: feet
+    cue "Close home, ready to chassé again"
+
+  repeat 4

--- a/spec/examples/grapevine.movit
+++ b/spec/examples/grapevine.movit
@@ -1,0 +1,35 @@
+movit exercise "Grapevine"
+  rig humanoid
+  pose start = standing
+
+  step "Step out" 0.7s ease-in-out:
+    hip_left: abduct 30
+    shoulders: abduct 40
+    travel: 0.4 0
+    ground-lock: feet
+    cue "Step the leading foot out to the side"
+
+  step "Cross behind" 0.7s ease-in-out:
+    hip_left: abduct 0
+    hip_right: rotate-in 20
+    knee_right: flex 25
+    travel: 0.8 0
+    ground-lock: feet
+    cue "Cross the trailing foot behind and keep travelling"
+
+  step "Step out again" 0.7s ease-in-out:
+    hip_right: rotate-in 0
+    knee_right: flex 0
+    hip_left: abduct 30
+    travel: 1.2 0
+    ground-lock: feet
+    cue "Step out to the side once more"
+
+  step "Return home" 1s ease-in-out:
+    hip_left: abduct 0
+    shoulders: abduct 0
+    travel: 0 0
+    ground-lock: feet
+    cue "Travel back the other way to the starting spot"
+
+  repeat 3

--- a/spec/examples/pirouette.movit
+++ b/spec/examples/pirouette.movit
@@ -1,0 +1,31 @@
+movit exercise "Pirouette"
+  rig humanoid
+  pose start = standing
+
+  step "Prep - plié" 1.2s ease-in-out:
+    hips: rotate-out 25
+    knees: flex 45
+    ankles: dorsiflex 10
+    shoulders: flex 40
+    elbows: flex 35
+    ground-lock: feet
+    cue "Plié to load the turn, arms rounded low in first"
+
+  step "Spot & spin" 1.4s ease-in-out:
+    knees: flex 0
+    ankles: plantarflex 30
+    shoulders: flex 95
+    elbows: flex 40
+    turn: 360
+    ground-lock: feet
+    cue "Push up to relevé, pull the arms in, and spin a full turn"
+
+  step "Land" 1s ease-out:
+    ankles: plantarflex 0
+    hips: rotate-out 0
+    shoulders: flex 0
+    elbows: flex 0
+    ground-lock: feet
+    cue "Land softly through the feet, arms floating back to the sides"
+
+  repeat 3

--- a/spec/examples/quarter-turns.movit
+++ b/spec/examples/quarter-turns.movit
@@ -1,0 +1,37 @@
+movit posture "Quarter turns"
+  rig humanoid
+  pose start = standing
+
+  step "Face right" 1s ease-in-out:
+    hips: flex 12
+    knees: flex 20
+    shoulders: abduct 30
+    turn: 90
+    ground-lock: feet
+    cue "Small dip and pivot a quarter-turn to the right"
+
+  step "Face back" 1s ease-in-out:
+    knees: flex 0
+    hips: flex 0
+    shoulders: abduct 0
+    turn: 180
+    ground-lock: feet
+    cue "Rise, then pivot another quarter-turn to face the back"
+
+  step "Face left" 1s ease-in-out:
+    hips: flex 12
+    knees: flex 20
+    shoulders: abduct 30
+    turn: 270
+    ground-lock: feet
+    cue "Dip and pivot again to face the far side"
+
+  step "Face front" 1s ease-in-out:
+    knees: flex 0
+    hips: flex 0
+    shoulders: abduct 0
+    turn: 360
+    ground-lock: feet
+    cue "Rise and complete the circle, back to front"
+
+  repeat 3

--- a/spec/examples/walk-cycle.movit
+++ b/spec/examples/walk-cycle.movit
@@ -1,0 +1,54 @@
+movit exercise "Walk & turn"
+  rig humanoid
+  pose start = standing
+
+  step "Step right" 0.7s ease-in-out:
+    hip_right: flex 30
+    knee_right: flex 15
+    hip_left: extend 12
+    shoulder_left: flex 25
+    shoulder_right: extend 20
+    travel: 0 0.4
+    ground-lock: feet
+    cue "Walk forward — right foot leads, opposite arm swings through"
+
+  step "Step left" 0.7s ease-in-out:
+    hip_left: flex 30
+    knee_left: flex 15
+    hip_right: extend 12
+    shoulder_right: flex 25
+    shoulder_left: extend 20
+    travel: 0 0.8
+    ground-lock: feet
+    cue "Left foot leads, arms swap — keep travelling forward"
+
+  step "About-face" 1s ease-in-out:
+    hips: flex 0
+    knees: flex 0
+    shoulders: flex 0
+    turn: 180
+    travel: 0 0.8
+    ground-lock: feet
+    cue "Plant and turn a half-turn to face back the way you came"
+
+  step "Walk back" 0.7s ease-in-out:
+    hip_right: flex 30
+    knee_right: flex 15
+    hip_left: extend 12
+    shoulder_left: flex 25
+    shoulder_right: extend 20
+    turn: 180
+    travel: 0 0.4
+    ground-lock: feet
+    cue "Walk back toward the start"
+
+  step "Arrive & square up" 1s ease-in-out:
+    hips: flex 0
+    knees: flex 0
+    shoulders: flex 0
+    turn: 360
+    travel: 0 0
+    ground-lock: feet
+    cue "Arrive home and turn to face front again"
+
+  repeat 2

--- a/spec/examples/waltz-box.movit
+++ b/spec/examples/waltz-box.movit
@@ -1,0 +1,41 @@
+movit stretch "Waltz box step"
+  rig humanoid
+  pose start = standing
+
+  step "1 - forward, rise" 1s ease-in-out:
+    hip_right: flex 25
+    knee_right: flex 20
+    ankles: plantarflex 12
+    shoulders: abduct 55
+    elbows: flex 20
+    travel: 0 0.4
+    ground-lock: feet
+    cue "Step forward onto the right foot and rise, arms in a soft frame"
+
+  step "2 - side, lower" 1s ease-in-out:
+    hip_right: flex 0
+    knee_right: flex 0
+    ankles: plantarflex 0
+    travel: -0.4 0.4
+    ground-lock: feet
+    cue "Side step to the corner and lower through the heels"
+
+  step "3 - back, rise" 1s ease-in-out:
+    hip_left: flex 25
+    knee_left: flex 20
+    ankles: plantarflex 12
+    travel: -0.4 0
+    ground-lock: feet
+    cue "Step back onto the left foot and rise again"
+
+  step "4 - close home" 1s ease-in-out:
+    hip_left: flex 0
+    knee_left: flex 0
+    ankles: plantarflex 0
+    shoulders: abduct 0
+    elbows: flex 0
+    travel: 0 0
+    ground-lock: feet
+    cue "Close to the start, completing the box"
+
+  repeat 3

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -21,6 +21,8 @@ movit <kind> "<Name>"          # kind = exercise | stretch | posture
     <joint>: <action> <degrees>
     reach: <effector> <target> # optional: drive a hand/foot to a target via IK
     ground-lock: <effectors>   # hands and/or feet pinned to the floor this phase
+    turn: <degrees>            # optional: face this yaw by phase end (standing only)
+    travel: <x> <z>            # optional: move to this x z (metres) by phase end
     cue "<short coaching cue>"
   repeat <count>
 ```
@@ -164,7 +166,17 @@ unset joints:
   `shoulders: flex 160, elbows: flex 20`. Move between them across phases.
 - **Plié:** `hips: flex 18, knees: flex 50, ankles: dorsiflex 12`.
 - **Relevé:** `ankles: plantarflex 28` (rise onto the balls of the feet).
+- **Turn / pirouette:** `turn: 360` (yaw in degrees, absolute). Pair with a
+  relevé to spin on the balls of the feet; `turn: 90` for a quarter-turn.
+- **Travel across the floor:** `travel: <x> <z>` (metres from the start spot,
+  absolute). A box-step traces a square back home:
+  `travel: 0.4 0` → `0.4 0.4` → `0 0.4` → `0 0`. A grapevine travels sideways;
+  a walk cycle steps forward in +z. Add the stepping legs with FK on top.
 
-Name each step by its count (`"5-6 - relevé, arms en haut"`) so the phrase reads
-like choreography. To extend a phrase, append more steps — the figure carries
-its pose forward. Use `ground-lock: feet` for grounded phrases.
+Both `turn` and `travel` are **absolute and carried forward** like joint angles,
+and both return home on the loop wrap, so phrases resolve cleanly. They work from
+**standing** poses only. Name each step by its count (`"5-6 - relevé, arms en
+haut"`) so the phrase reads like choreography. To extend a phrase, append more
+steps — the figure carries its pose forward. Use `ground-lock: feet` for grounded
+phrases (it still lets the figure turn and travel — it only keeps the feet on the
+floor vertically).


### PR DESCRIPTION
## Summary

Five changes, all aimed at how movements look and share:

### 1. Spatial choreography — `turn` & `travel`

The figure was **bolted to one spot facing one direction** — pirouettes, grapevines, box-steps, and walk cycles were impossible. Added two per-phase primitives: **`turn: <deg>`** (facing) and **`travel: <x> <z>`** (position, metres). Absolute targets carried across phases, returning home on the loop wrap. Plumbing mirrors `reach`/`pin` end to end; composes with grounding. New movements: `pirouette`, `box-step`, `grapevine`, `waltz-box`, `chasse`, `walk-cycle`, `quarter-turns`. Standing poses only.

### 2. Fix inverted shoulder/hip abduction

Longstanding bug (since v0.1): abduction swung limbs *inward across the body* instead of outward — wrong Z-axis sign in `joints.ts`. Fixed + regression test. Corrects ~20 movements (lateral raise, jumping jacks, arms-to-second, …).

### 3. Rig readability — A-pose arms + a face

Standing pose now abducts the shoulders ~11° so arms hang clear of the body instead of merging into the hips; a subtle nose + brow on the head's front makes facing legible (matters now that the figure turns).

### 4. Motion-aliveness layer

**Weight shift** (body leans over the planted ankle when a foot lifts — pivoting there, no foot skating; verified 3.8° lean / pelvis +3.1 cm over the stance foot at full knee lift, 0° on symmetric moves, skipped for lying/hanging), **follow-through** (distal segments trail their parent joints by tens of ms during playback; scrubbing snaps frame-exact), and **breath** (~1° chest oscillation, ~3.8 s cycle).

### 5. GIF & video export (+ hardening pass)

New `export…` control in the transport bar downloads exactly **one loop** of the current movement:
- **video (.webm)** — native MediaRecorder on a composited canvas; captures exactly what you see.
- **GIF** — rendered deterministically frame-by-frame (`seek → renderOnce → encode` via gifenc), a crisp perfectly-looping clip; adaptive fps/size keeps files sane.

Both burn in a caption band (phase name + coaching cue + "movit" mark) so a shared clip keeps the instruction. Engine support: `Viewer.renderOnce()`, `Viewer.setAutoRotate()`, `preserveDrawingBuffer`.

A follow-up audit hardened the whole path: robust video stop (wrap detected by time *decrease*; playback-ended stops non-looping passes — a loop-off export of a 3.6 s movement completes in 4.0 s instead of running to the hard cap), **camera orbit frozen during capture** so a clip's first/last frames share one angle (seamless replay), MediaRecorder failure recovery (state + UI always restored via `finally`), preset/edit lockdown mid-export, and a **mobile fix**: the transport bar now wraps on small screens — the export control was fully off-screen at 390 px (and the speed select was already clipped before this feature).

## Test plan

- [x] `npm test` — **154/154 pass**.
- [x] Full Playwright sweep of all 72 movements re-run after each engine-touching change — zero floor-clipping / zero grounding regressions.
- [x] Live telemetry + screenshots verify each behavior (turn/travel positions, abduction direction, A-pose gap, face, lean magnitude, breath amplitude).
- [x] Export audited end-to-end in headless Chromium by driving the real UI: prop+pin GIF (pull-up, 95 frames = exactly one 6.3 s loop), traveling GIF (grapevine), NETSCAPE2.0 infinite-loop flag present, WebM decodes and plays (mid-clip frame screenshot-checked), loop-off timing, post-export state restoration, and a full GIF export from a 390 px mobile viewport. Known cosmetic caveat: MediaRecorder WebM has no duration header (standard behavior).

## Follow-up (noted in ROADMAP)

Velocity-continuous phase blending and footstep-locked travel (true gait) are the next steps on this track.
