### PR TITLE
ROM-constrain reach-IK and expand effector groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ For where Movit spreads fastest and the per-domain go-to-market plan, see
 ## Scope (v0.1)
 
 ✅ Single-person movement across fitness, physio, desk, dance, education & rehab ·
-Mermaid-style DSL · ROM safety clamping · forward kinematics · ground-lock **and
-reach-to-target IK** · hip-hinge · lying/seated poses · scene props (chair/wall/
-bar) · a single-DOF hand rig · live playground.
+Mermaid-style DSL · ROM safety clamping (authored **and IK-solved** angles) ·
+forward kinematics · ground-lock **and ROM-constrained reach-to-target IK** ·
+hip-hinge · lying/seated poses · scene props (chair/wall/bar) · a single-DOF
+hand rig · live playground.
 
 ⏳ Deferred: two-person / partner movements + collision detection, deeper props
 (load, bands, rings), multi-joint fingers, FBX/GLB export, hosted SaaS editor and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,10 +29,13 @@ These are the unlocks, roughly in order of leverage:
    tips the torso forward over the hips while the legs stay planted (the renderer
    counter-rotates the hips). Powers `deadlift`, `bent-over-row`, `good-morning`,
    and `bow`. Next: hinge with a loaded-bar prop.
-2. ~~**Reach-IK (reach a world target)**~~ — ✅ **shipped.** `reach: <effector>
-   <target>` drives a hand/foot to a body landmark, the `floor`, or a prop anchor
-   via CCD. Powers `touch-toes`, `cross-body-reach`, `seated-forward-fold`, and
-   prop grips. Next: ROM-constrained reach + dual-hand targets.
+2. ~~**Reach-IK (reach a world target)**~~ — ✅ **shipped, now ROM-constrained.**
+   `reach: <effector> <target>` drives a hand/foot to a body landmark, the
+   `floor`, or a prop anchor via CCD. Powers `touch-toes`, `cross-body-reach`,
+   `seated-forward-fold`, and prop grips. The solve clamps every chain joint
+   into its Range-of-Motion box each iteration — solved angles obey the same
+   hard limits as authored ones — and `hands` / `feet` reach or pin both sides
+   in one line. Next: two-bone analytic solve for straighter elbows/knees.
 3. ~~**Scene props with contact anchors**~~ — ✅ **shipped (starter set).** `prop
    chair|wall|bar` adds a scene object with named anchors (`seat`, `wall`, `bar`).
    Powers `sit-to-stand`, `box-squat`, `wall-sit`, `dead-hang`, `hanging-knee-raise`.
@@ -77,8 +80,7 @@ Each prop is a small scene object + an anchor type; movements then reference it
 - One figure only; partner work and collision are still deferred.
 - A **starter** prop set (chair / wall / bar) — no bench, rings, bands, or loaded
   implements yet, and props sit at fixed default placements.
-- Reach-IK is **unconstrained** (no ROM limits on the solved chain) and props are
-  visual + reach anchors (no physical sit/lean solve).
+- Props are visual + reach anchors (no physical sit/lean solve).
 - Fingers are **single-DOF** curls — good for grip and rough gesture, not exact
   sign language. The head has no facial articulation.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "coverage": "vitest run --coverage",
     "dev": "npm run dev -w playground",
     "build": "npm run build -w playground",
-    "typecheck": "tsc -b --pretty"
+    "typecheck": "for p in packages/*/tsconfig.json playground/tsconfig.json editors/*/tsconfig.json; do tsc --noEmit -p \"$p\" || exit 1; done"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^2.1.8",

--- a/packages/movit-language/src/completion.ts
+++ b/packages/movit-language/src/completion.ts
@@ -9,6 +9,7 @@ import {
   KINDS,
   POSES,
   EFFECTORS,
+  REACH_EFFECTORS,
   EASINGS,
   JOINT_NAMES,
   ACTION_NAMES,
@@ -37,6 +38,7 @@ type Context =
   | "pose"
   | "easing"
   | "effector"
+  | "reach-effector"
   | "action"
   | "joint"
   | "top"
@@ -49,6 +51,7 @@ function contextFor(prefix: string, line: number): Context {
   if (/^\s*pose\s+start\s*=\s*[\w-]*$/.test(prefix)) return "pose";
   if (/^\s*step\s+"[^"]*"\s+[0-9.]+s\s+[\w-]*$/.test(prefix)) return "easing";
   if (/^\s*ground-lock\s*:\s*[\w,\s-]*$/.test(prefix)) return "effector";
+  if (/^\s*(reach|pin)\s*:\s*[\w-]*$/.test(prefix)) return "reach-effector";
   if (/^\s*[\w-]+\s*:\s*[\w-]*$/.test(prefix)) return "action";
 
   if (/^\s*[\w-]*$/.test(prefix)) {
@@ -80,6 +83,8 @@ export function getCompletions(
       return EASINGS.map((e) => item(e, "easing"));
     case "effector":
       return EFFECTORS.map((e) => item(e, "effector"));
+    case "reach-effector":
+      return REACH_EFFECTORS.map((e) => item(e, "effector"));
     case "action":
       return [...ACTION_NAMES, "hold"].map((a) => item(a, "action"));
     case "joint":

--- a/packages/movit-language/src/vocab.ts
+++ b/packages/movit-language/src/vocab.ts
@@ -4,7 +4,7 @@
  * drift from what the language actually accepts.
  */
 
-import { JOINT_NAMES, ACTION_NAMES, EASINGS } from "movit-parser";
+import { JOINT_NAMES, ACTION_NAMES, EASINGS, EFFECTOR_NAMES } from "movit-parser";
 
 export { JOINT_NAMES, ACTION_NAMES, EASINGS };
 
@@ -17,8 +17,8 @@ export const POSES = ["neutral", "standing", "plank", "supine", "prone", "seated
 /** Effectors that can be ground-locked. */
 export const EFFECTORS = ["hands", "feet"];
 
-/** Reach effectors (friendly aliases) and the scene props that supply anchors. */
-export const REACH_EFFECTORS = ["hand_left", "hand_right", "foot_left", "foot_right"];
+/** Reach/pin effectors (groups + per-side aliases) — sourced from the parser. */
+export const REACH_EFFECTORS = EFFECTOR_NAMES;
 export const PROPS = ["chair", "wall", "bar", "box"];
 
 /** Top-level directives (excluding the `movit` header keyword). */
@@ -37,8 +37,9 @@ export const KEYWORD_DOCS: Record<string, string> = {
   step: 'A movement phase — `step "<name>" <Ns> <easing>:`.',
   repeat: "How many times the movement loops.",
   "ground-lock": "Pins effectors (hands / feet) to the floor for this phase.",
-  reach: "Drives an effector to a target via IK — `reach: hand_left ankle_left`.",
-  pin: "Moves the body so an effector sits on an anchor — `pin: hand_left bar` (hang, pull up, step up, dip).",
+  reach:
+    "Drives an effector to a target via ROM-constrained IK — `reach: hand_left ankle_left`, `reach: hands floor`.",
+  pin: "Moves the body so an effector sits on an anchor — `pin: hands bar` (hang, pull up, step up, dip).",
   turn: "Turns the figure to face a new direction — `turn: 360` (degrees, yaw about vertical). Absolute, carried across phases. Standing poses only.",
   travel: "Moves the figure across the floor — `travel: 0.4 0` (world x z metres from the start spot). Absolute, carried across phases. Standing poses only.",
   cue: "A short coaching cue shown while this phase plays.",

--- a/packages/movit-language/test/language.test.ts
+++ b/packages/movit-language/test/language.test.ts
@@ -78,6 +78,13 @@ describe("getCompletions", () => {
       expect.arrayContaining(["hands", "feet"]),
     );
   });
+
+  it("suggests reach effectors (groups + sides) after `reach: ` and `pin: `", () => {
+    expect(onLine("    reach: ", 11)).toEqual(
+      expect.arrayContaining(["hands", "hand_left", "foot_right"]),
+    );
+    expect(onLine("    pin: ", 9)).toEqual(expect.arrayContaining(["feet"]));
+  });
 });
 
 describe("getHover", () => {

--- a/packages/movit-parser/src/clamp.ts
+++ b/packages/movit-parser/src/clamp.ts
@@ -13,11 +13,20 @@ import type {
   MovitIR,
   ParseError,
   Phase,
+  PinTarget,
+  ReachTarget,
   Warning,
 } from "./types.js";
 import { MOVIT_VERSION } from "./types.js";
 import type { AstDoc, AstStep } from "./parser.js";
-import { actionAxis, boneType, expandJoint, flexionSign, isLeft } from "./joints.js";
+import {
+  actionAxis,
+  boneType,
+  expandEffector,
+  expandJoint,
+  flexionSign,
+  isLeft,
+} from "./joints.js";
 import { clampAngle, romFor } from "./rom.js";
 
 export interface ResolveResult {
@@ -114,6 +123,28 @@ function resolveStep(
     euler,
   }));
 
+  // Reach / pin effectors: expand symmetric groups (`hands` → both hands) and
+  // reject unknown names — a typo'd effector would otherwise be silently
+  // ignored by the renderer, invisible to the authoring LLM.
+  const reaches: ReachTarget[] = [];
+  for (const r of step.reaches) {
+    const sides = expandEffector(r.effector);
+    if (sides.length === 0) {
+      errors.push({ line: r.line, message: `unknown reach effector: "${r.effector}"` });
+      continue;
+    }
+    for (const effector of sides) reaches.push({ effector, target: r.target });
+  }
+  const pins: PinTarget[] = [];
+  for (const p of step.pins) {
+    const sides = expandEffector(p.effector);
+    if (sides.length === 0) {
+      errors.push({ line: p.line, message: `unknown pin effector: "${p.effector}"` });
+      continue;
+    }
+    for (const effector of sides) pins.push({ effector, anchor: p.anchor });
+  }
+
   // Travel is clamped to a sane studio footprint (±TRAVEL_MAX m) so a stray
   // large value can't fling the figure off the ground plane / out of frame.
   const travel = step.travel
@@ -129,8 +160,8 @@ function resolveStep(
     easing: step.easing as Phase["easing"],
     targets,
     groundLock: step.groundLock,
-    reaches: step.reaches,
-    pins: step.pins,
+    reaches,
+    pins,
     ...(step.turn !== undefined ? { turnDeg: step.turn } : {}),
     ...(travel ? { travel } : {}),
     ...(step.cue ? { cue: step.cue } : {}),

--- a/packages/movit-parser/src/index.ts
+++ b/packages/movit-parser/src/index.ts
@@ -50,9 +50,11 @@ export {
   JOINT_GROUP_NAMES,
   JOINT_NAMES,
   ACTION_NAMES,
+  EFFECTOR_NAMES,
   expandJoint,
+  expandEffector,
   actionAxis,
   boneType,
 } from "./joints.js";
-export { romFor, clampAngle, type RomLimit } from "./rom.js";
+export { romFor, clampAngle, eulerRomFor, type RomLimit, type EulerRom } from "./rom.js";
 export { EASINGS } from "./schema.js";

--- a/packages/movit-parser/src/joints.ts
+++ b/packages/movit-parser/src/joints.ts
@@ -95,6 +95,36 @@ export function expandJoint(name: string): string[] {
   return [];
 }
 
+/** Per-side reach/pin effectors (friendly aliases the renderer maps to bones). */
+const EFFECTOR_SIDES = [
+  "hand_left",
+  "hand_right",
+  "foot_left",
+  "foot_right",
+] as const;
+
+/** Symmetric effector groups → the per-side effectors they expand to. */
+const EFFECTOR_GROUPS: Record<string, string[]> = {
+  hands: ["hand_left", "hand_right"],
+  feet: ["foot_left", "foot_right"],
+};
+
+/** Every effector name `reach:` / `pin:` accept: groups + per-side aliases. */
+export const EFFECTOR_NAMES = [...Object.keys(EFFECTOR_GROUPS), ...EFFECTOR_SIDES];
+
+const EFFECTOR_SIDE_SET = new Set<string>(EFFECTOR_SIDES);
+
+/**
+ * Resolve a reach/pin effector name into per-side effectors (`hands` →
+ * both hands). Returns an empty array if the name is unknown (caller errors).
+ */
+export function expandEffector(name: string): string[] {
+  const group = EFFECTOR_GROUPS[name];
+  if (group) return [...group];
+  if (EFFECTOR_SIDE_SET.has(name)) return [name];
+  return [];
+}
+
 export interface ActionAxis {
   axis: Axis;
   /** +1 or -1 in the bone's local frame (before left/right mirroring). */

--- a/packages/movit-parser/src/parser.ts
+++ b/packages/movit-parser/src/parser.ts
@@ -19,11 +19,13 @@ export interface AstJointTarget {
 export interface AstReach {
   effector: string;
   target: string;
+  line: number;
 }
 
 export interface AstPin {
   effector: string;
   anchor: string;
+  line: number;
 }
 
 export interface AstStep {
@@ -212,7 +214,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
     if (t[1]?.type !== "colon" || !effector || !target) {
       return { line: ln.line, message: "expected `reach: <effector> <target>`" };
     }
-    current.reaches.push({ effector, target });
+    current.reaches.push({ effector, target, line: ln.line });
     return null;
   }
 
@@ -224,7 +226,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
     if (t[1]?.type !== "colon" || !effector || !anchor) {
       return { line: ln.line, message: "expected `pin: <effector> <anchor>`" };
     }
-    current.pins.push({ effector, anchor });
+    current.pins.push({ effector, anchor, line: ln.line });
     return null;
   }
 

--- a/packages/movit-parser/src/rom.ts
+++ b/packages/movit-parser/src/rom.ts
@@ -98,13 +98,52 @@ const ROM: Record<string, ActionLimits> = {
   },
 };
 
-import { boneType } from "./joints.js";
+import { actionAxis, boneType, flexionSign, isLeft } from "./joints.js";
+import type { Axis } from "./types.js";
 
 /** Look up the ROM limit for a bone + action, or null if undefined. */
 export function romFor(boneId: string, action: string): RomLimit | null {
   const limits = ROM[boneType(boneId)];
   if (!limits) return null;
   return limits[action] ?? null;
+}
+
+/** Signed per-axis rotation range, degrees, in a bone's LOCAL Euler frame. */
+export type EulerRom = Record<Axis, RomLimit>;
+
+/**
+ * The full ROM of a bone expressed as a signed Euler box in the renderer's
+ * local frame — the same frame `clamp.ts` resolves authored actions into
+ * (flexion-sign per joint, Y/Z mirrored on left-side bones). Each axis range is
+ * the union of every action that rotates it; axes with no ROM entry stay
+ * `{min: 0, max: 0}`, locking them (a knee is a pure hinge). This is what lets
+ * the IK solver honour the same hard limits as authored angles: any solved
+ * joint rotation clamped into this box is inside the healthy ROM.
+ *
+ * Returns null for bones without ROM data (e.g. `head`).
+ */
+export function eulerRomFor(boneId: string): EulerRom | null {
+  const limits = ROM[boneType(boneId)];
+  if (!limits) return null;
+
+  const box: EulerRom = {
+    x: { min: 0, max: 0 },
+    y: { min: 0, max: 0 },
+    z: { min: 0, max: 0 },
+  };
+  for (const [action, rom] of Object.entries(limits)) {
+    const aa = actionAxis(action);
+    if (!aa) continue;
+    // Mirrors the sign resolution in clamp.ts exactly.
+    const flexFlip =
+      action === "flex" || action === "extend" ? flexionSign(boneType(boneId)) : 1;
+    const mirror = isLeft(boneId) && aa.axis !== "x" ? -1 : 1;
+    const sign = aa.sign * flexFlip * mirror;
+    const range = box[aa.axis];
+    range.min = Math.min(range.min, sign * rom.min, sign * rom.max);
+    range.max = Math.max(range.max, sign * rom.min, sign * rom.max);
+  }
+  return box;
 }
 
 /**

--- a/packages/movit-parser/src/schema.ts
+++ b/packages/movit-parser/src/schema.ts
@@ -23,11 +23,13 @@ const jointTargetSchema = z.object({
 const reachSchema = z.object({
   effector: z.string().min(1),
   target: z.string().min(1),
+  line: z.number(),
 });
 
 const pinSchema = z.object({
   effector: z.string().min(1),
   anchor: z.string().min(1),
+  line: z.number(),
 });
 
 const stepSchema = z.object({

--- a/packages/movit-parser/test/parse.test.ts
+++ b/packages/movit-parser/test/parse.test.ts
@@ -166,3 +166,46 @@ describe("parse", () => {
     expect(errors.some((e) => /travel/i.test(e.message))).toBe(true);
   });
 });
+
+describe("reach/pin effectors", () => {
+  it("expands `hands` / `feet` into per-side effectors", () => {
+    const { ir, errors } = parse(
+      [
+        'movit stretch "Fold"',
+        "  rig humanoid",
+        "  pose start = standing",
+        "  prop box",
+        '  step "Fold" 2s ease-in-out:',
+        "    pelvis: hinge 90",
+        "    reach: hands floor",
+        "    pin: feet box",
+        "  repeat 1",
+      ].join("\n"),
+    );
+    expect(errors).toEqual([]);
+    expect(ir!.phases[0]!.reaches).toEqual([
+      { effector: "hand_left", target: "floor" },
+      { effector: "hand_right", target: "floor" },
+    ]);
+    expect(ir!.phases[0]!.pins).toEqual([
+      { effector: "foot_left", anchor: "box" },
+      { effector: "foot_right", anchor: "box" },
+    ]);
+  });
+
+  it("rejects an unknown effector with a line-anchored error", () => {
+    const { ir, errors } = parse(
+      [
+        'movit stretch "Typo"',
+        "  rig humanoid",
+        '  step "Reach" 1s linear:',
+        "    reach: tentacle floor",
+        "  repeat 1",
+      ].join("\n"),
+    );
+    expect(ir).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.line).toBe(4);
+    expect(errors[0]!.message).toContain("tentacle");
+  });
+});

--- a/packages/movit-parser/test/rom.test.ts
+++ b/packages/movit-parser/test/rom.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { romFor } from "../src/rom.js";
+import { romFor, eulerRomFor } from "../src/rom.js";
 import { expandJoint, actionAxis } from "../src/joints.js";
 
 describe("rom table", () => {
@@ -44,5 +44,38 @@ describe("joint vocabulary", () => {
 
   it("returns null for an unknown action", () => {
     expect(actionAxis("teleport")).toBeNull();
+  });
+});
+
+describe("euler ROM boxes (eulerRomFor)", () => {
+  it("unions elbow flex/extend into a signed X range (flex is -X off the knee)", () => {
+    const box = eulerRomFor("elbow_right")!;
+    expect(box.x).toEqual({ min: -154, max: 10 }); // flex 154 → -X, extend 10 → +X
+  });
+
+  it("locks axes with no ROM entry, making the knee a pure hinge", () => {
+    const box = eulerRomFor("knee_right")!;
+    expect(box.x).toEqual({ min: -5, max: 144 }); // knee flexes toward +X
+    expect(box.y).toEqual({ min: 0, max: 0 });
+    expect(box.z).toEqual({ min: 0, max: 0 });
+  });
+
+  it("mirrors Y/Z ranges on left-side bones", () => {
+    const right = eulerRomFor("elbow_right")!;
+    const left = eulerRomFor("elbow_left")!;
+    // supinate 92 / pronate 84 flip sides under the mirror.
+    expect(right.y).toEqual({ min: -84, max: 92 });
+    expect(left.y).toEqual({ min: -92, max: 84 });
+    // X (sagittal) is never mirrored.
+    expect(left.x).toEqual(right.x);
+  });
+
+  it("covers the ankle via dorsiflex/plantarflex and the pelvis via hinge", () => {
+    expect(eulerRomFor("ankle_left")!.x).toEqual({ min: -50, max: 15 });
+    expect(eulerRomFor("pelvis")!.x).toEqual({ min: -120, max: 0 });
+  });
+
+  it("returns null for a bone without ROM data", () => {
+    expect(eulerRomFor("head")).toBeNull();
   });
 });

--- a/packages/movit-render/src/ik.ts
+++ b/packages/movit-render/src/ik.ts
@@ -3,16 +3,34 @@
  * bone chain — the §6.2 algorithm, adapted to our rigid-segment rig (Three's
  * built-in CCDIKSolver is bound to SkinnedMesh, which we don't use).
  *
- * Used for ground-lock: pinning a hand/foot effector to a fixed floor target
- * while the rest of the body moves. v0.1 runs unconstrained CCD; ROM-aware
- * angle limits on the chain are deferred to a later version.
+ * Used for ground-lock and reach: pinning or driving a hand/foot effector to a
+ * world target while the rest of the body moves. Chains may carry per-joint
+ * Euler angle limits (the joint's Range of Motion expressed as a local-frame
+ * box, see movit-parser's `eulerRomFor`); each iteration clamps the joint back
+ * inside its box, so a solved pose can never exceed the healthy ROM any more
+ * than an authored angle can.
  */
 
 import * as THREE from "three";
 
+/**
+ * Per-axis rotation limits (radians) in a joint's LOCAL Euler (XYZ) frame.
+ * Axes the joint cannot rotate use `[0, 0]` — e.g. a knee is a pure hinge.
+ */
+export interface JointLimits {
+  x: [number, number];
+  y: [number, number];
+  z: [number, number];
+}
+
 export interface IkChain {
   /** Joints that may rotate, ordered proximal → distal. */
   joints: THREE.Object3D[];
+  /**
+   * Optional ROM limits, parallel to `joints` (null/undefined = unconstrained).
+   * Clamped every iteration so the solve stays inside the box throughout.
+   */
+  limits?: (JointLimits | null | undefined)[];
   /** The node whose world position should reach the target. */
   effector: THREE.Object3D;
   /** World-space goal for the effector. */
@@ -26,6 +44,7 @@ const TMP_TO_TARGET = new THREE.Vector3();
 const TMP_AXIS = new THREE.Vector3();
 const TMP_QUAT = new THREE.Quaternion();
 const TMP_PARENT_QUAT = new THREE.Quaternion();
+const TMP_EULER = new THREE.Euler();
 
 /**
  * Solve one chain in place. Rotates `joints` so `effector` approaches `target`.
@@ -64,6 +83,7 @@ export function solveCCD(chain: IkChain, iterations = 10, tolerance = 1e-4): num
       );
       const localQuat = new THREE.Quaternion().setFromAxisAngle(localAxis, angle);
       joint.quaternion.premultiply(localQuat);
+      clampToLimits(joint, chain.limits?.[j]);
       joint.updateMatrixWorld(true);
     }
 
@@ -74,6 +94,18 @@ export function solveCCD(chain: IkChain, iterations = 10, tolerance = 1e-4): num
   root.updateMatrixWorld(true);
   effector.getWorldPosition(TMP_EFF);
   return TMP_EFF.distanceToSquared(target);
+}
+
+/** Clamp a joint's local rotation into its per-axis Euler box, if it has one. */
+function clampToLimits(joint: THREE.Object3D, limits: JointLimits | null | undefined): void {
+  if (!limits) return;
+  TMP_EULER.setFromQuaternion(joint.quaternion, "XYZ");
+  const x = THREE.MathUtils.clamp(TMP_EULER.x, limits.x[0], limits.x[1]);
+  const y = THREE.MathUtils.clamp(TMP_EULER.y, limits.y[0], limits.y[1]);
+  const z = THREE.MathUtils.clamp(TMP_EULER.z, limits.z[0], limits.z[1]);
+  if (x === TMP_EULER.x && y === TMP_EULER.y && z === TMP_EULER.z) return;
+  TMP_EULER.set(x, y, z, "XYZ");
+  joint.quaternion.setFromEuler(TMP_EULER);
 }
 
 function topmostParent(node: THREE.Object3D): THREE.Object3D {

--- a/packages/movit-render/src/index.ts
+++ b/packages/movit-render/src/index.ts
@@ -10,10 +10,11 @@
 
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { eulerRomFor } from "movit-parser";
 import type { MovitIR, ReachTarget, PinTarget } from "movit-parser";
 import { buildMannequin, type Mannequin } from "./mannequin.js";
 import { buildTimeline, type BuiltTimeline, type PhaseSegment } from "./timeline.js";
-import { solveCCD } from "./ik.js";
+import { solveCCD, type JointLimits } from "./ik.js";
 import { buildProps, type PropScene } from "./props.js";
 
 const DEG = Math.PI / 180;
@@ -302,17 +303,52 @@ export function createViewer(
     foot_right: "ankle_right",
   };
 
-  /** The rotatable joint chain (proximal → distal) that moves an effector. */
-  function reachChain(effectorBone: string): THREE.Object3D[] {
+  /**
+   * The rotatable joint chain (proximal → distal) that moves an effector, with
+   * each joint's ROM expressed as local Euler limits for the constrained solve.
+   * A limit box is widened to include the joint's CURRENT (authored FK) angle:
+   * the timeline pose is already ROM-clamped in author terms, but rig mechanics
+   * such as the hip-hinge counter-rotation can place a bone outside its raw box
+   * on purpose — IK must never fight the authored pose, only be prevented from
+   * pushing beyond it.
+   */
+  function reachChain(effectorBone: string): {
+    joints: THREE.Object3D[];
+    limits: (JointLimits | null)[];
+  } {
     const side = effectorBone.endsWith("_left") ? "left" : "right";
     const ids = effectorBone.startsWith("wrist")
       ? [`shoulder_${side}`, `elbow_${side}`]
       : effectorBone.startsWith("ankle")
         ? [`hip_${side}`, `knee_${side}`]
         : [];
-    return ids
-      .map((id) => mannequin.bones.get(id))
-      .filter((n): n is THREE.Object3D => !!n);
+    const joints: THREE.Object3D[] = [];
+    const limits: (JointLimits | null)[] = [];
+    for (const id of ids) {
+      const node = mannequin.bones.get(id);
+      if (!node) continue;
+      joints.push(node);
+      limits.push(jointLimitsFor(id, node));
+    }
+    return { joints, limits };
+  }
+
+  const REACH_EULER = new THREE.Euler();
+
+  /** A bone's ROM as radian Euler limits, widened to admit its current pose. */
+  function jointLimitsFor(boneId: string, node: THREE.Object3D): JointLimits | null {
+    const rom = eulerRomFor(boneId);
+    if (!rom) return null;
+    REACH_EULER.setFromQuaternion(node.quaternion, "XYZ");
+    return {
+      x: widen(rom.x.min * DEG, rom.x.max * DEG, REACH_EULER.x),
+      y: widen(rom.y.min * DEG, rom.y.max * DEG, REACH_EULER.y),
+      z: widen(rom.z.min * DEG, rom.z.max * DEG, REACH_EULER.z),
+    };
+  }
+
+  function widen(min: number, max: number, current: number): [number, number] {
+    return [Math.min(min, current), Math.max(max, current)];
   }
 
   /** Resolve a reach target name to a world point: floor / prop anchor / landmark. */
@@ -333,10 +369,12 @@ export function createViewer(
   }
 
   /**
-   * Reach-IK: drive each active effector to its world target with CCD. Runs
-   * AFTER ground-lock so landmark/floor targets are resolved against the final
-   * root placement. The chain is the arm (hand) or the leg (foot); other joints
-   * keep their authored FK pose.
+   * Reach-IK: drive each active effector to its world target with ROM-
+   * constrained CCD — the solved arm/leg obeys the same hard joint limits as
+   * authored angles, so an unreachable target yields the closest SAFE pose.
+   * Runs AFTER ground-lock so landmark/floor targets are resolved against the
+   * final root placement. The chain is the arm (hand) or the leg (foot); other
+   * joints keep their authored FK pose.
    */
   function applyReaches(reaches: ReachTarget[]): void {
     for (const r of reaches) {
@@ -345,9 +383,9 @@ export function createViewer(
       if (!effector) continue;
       const target = resolveReachTarget(r.target, effector);
       if (!target) continue;
-      const joints = reachChain(effectorBone);
+      const { joints, limits } = reachChain(effectorBone);
       if (joints.length === 0) continue;
-      solveCCD({ joints, effector, target }, 12);
+      solveCCD({ joints, limits, effector, target }, 12);
     }
   }
 
@@ -590,6 +628,6 @@ function disposeTree(root: THREE.Object3D): void {
 
 export { buildMannequin } from "./mannequin.js";
 export { buildTimeline } from "./timeline.js";
-export { solveCCD } from "./ik.js";
+export { solveCCD, type IkChain, type JointLimits } from "./ik.js";
 export { buildProps, type PropScene } from "./props.js";
 export type { PhaseSegment } from "./timeline.js";

--- a/packages/movit-render/test/render.test.ts
+++ b/packages/movit-render/test/render.test.ts
@@ -5,7 +5,7 @@ import { buildTimeline } from "../src/timeline.js";
 import { solveCCD } from "../src/ik.js";
 import { poseFor } from "../src/poses.js";
 import { buildProps } from "../src/props.js";
-import { parse } from "movit-parser";
+import { parse, eulerRomFor } from "movit-parser";
 
 const DEG = Math.PI / 180;
 
@@ -347,5 +347,114 @@ describe("ccd ik", () => {
     const target = new THREE.Vector3(1.4, 0.6, 0);
     const distSq = solveCCD({ joints: [j0, j1], effector, target }, 30);
     expect(Math.sqrt(distSq)).toBeLessThan(0.05);
+  });
+});
+
+describe("ROM-constrained reach-IK", () => {
+  // The viewer's radian limit boxes, minus the current-pose widening (the rig
+  // starts at rest here, which is inside every box).
+  function limitsFor(id: string) {
+    const rom = eulerRomFor(id);
+    if (!rom) return null;
+    const r = (d: number) => d * DEG;
+    return {
+      x: [r(rom.x.min), r(rom.x.max)] as [number, number],
+      y: [r(rom.y.min), r(rom.y.max)] as [number, number],
+      z: [r(rom.z.min), r(rom.z.max)] as [number, number],
+    };
+  }
+
+  function armChain(m: ReturnType<typeof buildMannequin>) {
+    const shoulder = m.bones.get("shoulder_right")!;
+    const elbow = m.bones.get("elbow_right")!;
+    return {
+      joints: [shoulder, elbow],
+      limits: [limitsFor("shoulder_right"), limitsFor("elbow_right")],
+      effector: m.bones.get("wrist_right")!,
+    };
+  }
+
+  it("still converges on a reachable in-front target", () => {
+    const m = buildMannequin();
+    m.root.updateMatrixWorld(true);
+    const { joints, limits, effector } = armChain(m);
+    const target = joints[0]!
+      .getWorldPosition(new THREE.Vector3())
+      .add(new THREE.Vector3(0.3, -0.2, 0.3));
+
+    solveCCD({ joints, limits, effector, target }, 20);
+    m.root.updateMatrixWorld(true);
+    expect(
+      effector.getWorldPosition(new THREE.Vector3()).distanceTo(target),
+    ).toBeLessThan(0.06);
+  });
+
+  it("never pushes a chain joint past its ROM chasing an unsafe target", () => {
+    const m = buildMannequin();
+    m.root.updateMatrixWorld(true);
+    const { joints, limits, effector } = armChain(m);
+    const [shoulder, elbow] = joints;
+    // High behind the back (figure faces +Z): reaching it would demand
+    // shoulder extension far past the 60° healthy ceiling.
+    const target = shoulder!
+      .getWorldPosition(new THREE.Vector3())
+      .add(new THREE.Vector3(0, 0.3, -0.5));
+
+    solveCCD({ joints, limits, effector, target }, 30);
+    m.root.updateMatrixWorld(true);
+
+    const eps = 1e-6;
+    for (const [joint, lim] of [
+      [shoulder!, limits[0]!],
+      [elbow!, limits[1]!],
+    ] as const) {
+      const e = new THREE.Euler().setFromQuaternion(joint.quaternion, "XYZ");
+      expect(e.x).toBeGreaterThanOrEqual(lim.x[0] - eps);
+      expect(e.x).toBeLessThanOrEqual(lim.x[1] + eps);
+      expect(e.y).toBeGreaterThanOrEqual(lim.y[0] - eps);
+      expect(e.y).toBeLessThanOrEqual(lim.y[1] + eps);
+      expect(e.z).toBeGreaterThanOrEqual(lim.z[0] - eps);
+      expect(e.z).toBeLessThanOrEqual(lim.z[1] + eps);
+    }
+    // Sanity: unconstrained CCD DOES violate the shoulder ceiling here, so the
+    // clamp above is load-bearing, not vacuous.
+    const m2 = buildMannequin();
+    m2.root.updateMatrixWorld(true);
+    const free = armChain(m2);
+    const target2 = free.joints[0]!
+      .getWorldPosition(new THREE.Vector3())
+      .add(new THREE.Vector3(0, 0.3, -0.5));
+    solveCCD({ joints: free.joints, effector: free.effector, target: target2 }, 30);
+    const eFree = new THREE.Euler().setFromQuaternion(
+      free.joints[0]!.quaternion,
+      "XYZ",
+    );
+    expect(eFree.x).toBeGreaterThan(60 * DEG + 0.05); // past healthy extension
+  });
+
+  it("keeps a knee hinge-only: no lateral splay while a foot reaches", () => {
+    const m = buildMannequin();
+    m.root.updateMatrixWorld(true);
+    const hip = m.bones.get("hip_right")!;
+    const knee = m.bones.get("knee_right")!;
+    const ankle = m.bones.get("ankle_right")!;
+    // A target out to the side tempts unconstrained CCD to twist the knee
+    // sideways; the ROM box zeroes the knee's Y/Z axes.
+    const target = hip
+      .getWorldPosition(new THREE.Vector3())
+      .add(new THREE.Vector3(-0.5, -0.3, 0.2));
+
+    solveCCD(
+      {
+        joints: [hip, knee],
+        limits: [limitsFor("hip_right"), limitsFor("knee_right")],
+        effector: ankle,
+        target,
+      },
+      30,
+    );
+    const e = new THREE.Euler().setFromQuaternion(knee.quaternion, "XYZ");
+    expect(Math.abs(e.y)).toBeLessThan(1e-6);
+    expect(Math.abs(e.z)).toBeLessThan(1e-6);
   });
 });

--- a/playground/src/landing.ts
+++ b/playground/src/landing.ts
@@ -42,7 +42,9 @@ function initHero(): void {
 if ("requestIdleCallback" in window) {
   requestIdleCallback(initHero, { timeout: 1200 });
 } else {
-  window.setTimeout(initHero, 200);
+  // `window` narrows to `never` here (lib.dom always declares
+  // requestIdleCallback), so call the global directly.
+  setTimeout(initHero, 200);
 }
 
 // --- Examples gallery: a curated taste, not the full 65 ---------------------

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -33,7 +33,7 @@ easing     = "linear" | "ease-in" | "ease-out" | "ease-in-out" ;
 child      = jointTarget | groundLock | reach | pin | turn | travel | cue ;
 jointTarget= joint ":" action [ NUMBER ] ;
 groundLock = "ground-lock" ":" effector { "," effector } ;
-reach      = "reach" ":" effector target ;             (* effector → world target via IK *)
+reach      = "reach" ":" effector target ;             (* effector → world target via ROM-constrained IK *)
 pin        = "pin" ":" effector anchor ;               (* move the BODY so effector sits on anchor *)
 turn       = "turn" ":" NUMBER ;                       (* face this yaw (deg) by phase end *)
 travel     = "travel" ":" NUMBER NUMBER ;              (* move to this x z (metres) by phase end *)
@@ -126,17 +126,23 @@ research §5.1 normative tables. Selected ceilings (degrees):
 3. **Ground-lock IK** — effectors listed in `ground-lock` (`hands`, `feet`) are
    pinned to their planted floor position so they stay put while the body moves.
 4. **Reach-IK** — a `reach:` line drives an effector (`hand_left|hand_right|
-   foot_left|foot_right`) to a world **target** via Cyclic Coordinate Descent
-   (CCD) over the arm/leg chain. A target is a body landmark bone (e.g.
-   `ankle_left`), the keyword `floor`, or a prop anchor (`bar`, `seat`, `wall`).
+   foot_left|foot_right`, or the groups `hands`/`feet` for both sides) to a
+   world **target** via Cyclic Coordinate Descent (CCD) over the arm/leg chain.
+   A target is a body landmark bone (e.g. `ankle_left`), the keyword `floor`,
+   or a prop anchor (`bar`, `seat`, `wall`). The solve is **ROM-constrained**:
+   each iteration clamps every chain joint into its §4 Range-of-Motion limits
+   (expressed as a per-axis box in the bone's local Euler frame), so a reach
+   toward an unsafe or unreachable target settles on the closest *healthy*
+   pose — solved angles obey the same hard limits as authored ones.
 5. **Props** — `prop chair|wall|bar|box` adds a scene object at a fixed default
    placement (chair/wall behind, bar overhead, box in front); its named anchors
    become reach/pin targets.
 6. **Pins** — `pin: <effector> <anchor>` translates the whole figure so the
-   effector sits on the anchor. Where ground-lock keeps a foot on the floor and
-   reach moves a limb to a target, a **pin moves the body** while the contact
-   stays put — so the figure hangs from a bar, pulls up toward it, rises onto a
-   box, or lowers into a dip as the joints work.
+   effector sits on the anchor (effectors accept the same `hands`/`feet` groups
+   as reach — `pin: hands bar` pins both). Where ground-lock keeps a foot on
+   the floor and reach moves a limb to a target, a **pin moves the body** while
+   the contact stays put — so the figure hangs from a bar, pulls up toward it,
+   rises onto a box, or lowers into a dip as the joints work.
 7. **Spatial choreography** — `turn: <deg>` rotates the figure's facing (yaw
    about vertical) and `travel: <x> <z>` moves it across the floor (world metres
    from the load spot). Both are **absolute targets carried across phases** (like

--- a/spec/examples/dead-hang.movit
+++ b/spec/examples/dead-hang.movit
@@ -12,8 +12,7 @@ movit exercise "Dead hang"
   step "Hang" 3s ease-in-out:
     shoulders: flex 175
     elbows: flex 5
-    pin: hand_left bar
-    pin: hand_right bar
+    pin: hands bar
     cue "Relax into a long, straight-arm hang"
 
   step "Down" 1.5s ease-out:

--- a/spec/examples/pull-up.movit
+++ b/spec/examples/pull-up.movit
@@ -12,22 +12,19 @@ movit exercise "Pull-up"
   step "Hang" 0.7s ease-in-out:
     shoulders: flex 175
     elbows: flex 5
-    pin: hand_left bar
-    pin: hand_right bar
+    pin: hands bar
     cue "Hang from the bar, arms long, shoulders active"
 
   step "Pull up" 1.2s ease-out:
     shoulders: flex 150
     elbows: flex 130
-    pin: hand_left bar
-    pin: hand_right bar
+    pin: hands bar
     cue "Pull the chest toward the bar, driving the elbows down"
 
   step "Lower" 1.4s ease-in:
     shoulders: flex 175
     elbows: flex 5
-    pin: hand_left bar
-    pin: hand_right bar
+    pin: hands bar
     cue "Lower under control back to a full hang"
 
   step "Release" 0.8s ease-in:

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -111,10 +111,13 @@ movit exercise "Deadlift"
 ## Reaching, props, lying poses & hands
 
 - **Reach a target** — `reach: <effector> <target>` drives a hand or foot to a
-  world point via IK. Effectors: `hand_left hand_right foot_left foot_right`.
-  Targets: a body landmark bone (`ankle_left`, `knee_right`…), `floor`, or a prop
-  anchor (`bar`, `seat`, `wall`). Author the gross pose (e.g. a `pelvis: hinge`),
-  then let `reach` finish the hand placement. Example — touch your toes:
+  world point via IK. Effectors: `hand_left hand_right foot_left foot_right`,
+  or `hands` / `feet` for both sides at once. Targets: a body landmark bone
+  (`ankle_left`, `knee_right`…), `floor`, or a prop anchor (`bar`, `seat`,
+  `wall`). The solve is ROM-constrained — the arm/leg can never exceed the safe
+  joint limits chasing a target, so an out-of-reach target just yields the
+  closest healthy pose. Author the gross pose (e.g. a `pelvis: hinge`), then
+  let `reach` finish the hand placement. Example — touch your toes:
 
   ```movit
   step "Fold" 2.5s ease-in-out:
@@ -130,10 +133,10 @@ movit exercise "Deadlift"
   the figure (sit-to-stand, box squat), the wall behind that (wall sit), the bar
   overhead, the box in front (step-ups).
 - **Pins** — `pin: <effector> <anchor>` moves the whole BODY so the effector sits
-  on the anchor (vs `reach`, which moves just the limb). Use it for hanging and
-  climbing: `pin: hand_left bar` + flexing the elbows = a pull-up; `pin: foot_right
-  box` + straightening the leg = a step-up; `pin: hand_left seat` + bending the
-  elbows = a triceps dip.
+  on the anchor (vs `reach`, which moves just the limb). Same effectors as reach,
+  including `hands` / `feet`. Use it for hanging and climbing: `pin: hands bar` +
+  flexing the elbows = a pull-up; `pin: foot_right box` + straightening the leg =
+  a step-up; `pin: hands seat` + bending the elbows = a triceps dip.
 - **Lying / seated** — `pose start = supine | prone | seated` for floor and mat
   work (glute bridge, dead bug, cobra, seated forward fold).
 - **Hands** — `fingers: flex 80` makes a fist; curl individual fingers for shapes


### PR DESCRIPTION
## Summary

This PR adds Range-of-Motion (ROM) constraints to the reach-IK solver and enables symmetric effector groups (`hands`/`feet`) in reach and pin targets. Solved joint angles now obey the same hard limits as authored angles, so reaching toward an unsafe or unreachable target settles on the closest healthy pose rather than violating joint limits.

## Key Changes

- **ROM-constrained CCD solver** — The IK solver now accepts optional per-joint Euler angle limits (a local-frame box per axis). Each iteration clamps solved rotations into these boxes, ensuring the chain never exceeds healthy ROM.

- **Euler ROM box computation** — Added `eulerRomFor()` in `movit-parser` to express a bone's full ROM as a signed per-axis Euler box in the renderer's local frame, unioning all actions that rotate each axis and mirroring Y/Z on left-side bones to match authored angle semantics.

- **Effector group expansion** — Reach and pin targets now accept symmetric groups (`hands` → both hands, `feet` → both feet) in addition to per-side aliases (`hand_left`, `foot_right`, etc.). The parser validates effector names and rejects unknowns with line-anchored errors.

- **Viewer integration** — The reach-IK caller now computes ROM limits for each chain joint by widening the raw ROM box to admit the joint's current (authored FK) pose, then passes these limits to the solver. This prevents IK from fighting the authored pose while preventing it from pushing beyond the healthy ROM.

- **Test coverage** — Added comprehensive tests for ROM-constrained reach-IK (reachable targets, unreachable targets, hinge-only joints) and effector group expansion.

## Implementation Details

- ROM limits are widened to include the current pose because rig mechanics (e.g., hip-hinge counter-rotation) can place a bone outside its raw ROM box on purpose — IK must never fight the authored pose.
- The solver uses `THREE.Euler` with "XYZ" order to match the authored angle frame, ensuring clamped angles are semantically equivalent to authored ones.
- Effector validation happens during parsing, so typos are caught immediately with clear error messages rather than silently ignored by the renderer.
- Documentation and examples updated to reflect the new ROM-constrained behavior and symmetric effector syntax.

https://claude.ai/code/session_0164eTtmmq6U8GQkAEmQsvV5