### PR TITLE
Remove em dashes across the entire repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">◆ Posecode</h1>
 
 <p align="center"><b>Kinematic motion as text.</b> Mermaid gave LLMs a way to draw diagrams.<br/>
-Posecode gives them a way to <i>show movement</i> — exercises, physiotherapy, posture —<br/>
+Posecode gives them a way to <i>show movement</i>: exercises, physiotherapy, posture,<br/>
 as a tiny human-readable language that renders to an animated 3D figure in the browser.</p>
 
 <p align="center">
@@ -14,9 +14,9 @@ as a tiny human-readable language that renders to an animated 3D figure in the b
 
 <table align="center">
   <tr>
-    <td align="center"><img src="docs/media/deadlift.gif" width="230" alt="Deadlift rendered from .posecode text"/><br/><sub><code>pelvis: hinge</code> — deadlift</sub></td>
-    <td align="center"><img src="docs/media/squat.gif" width="230" alt="Body-weight squat rendered from .posecode text"/><br/><sub><code>knees: flex 95</code> — squat</sub></td>
-    <td align="center"><img src="docs/media/lateral-raise.gif" width="230" alt="Lateral raise rendered from .posecode text"/><br/><sub><code>shoulders: abduct 90</code> — lateral raise</sub></td>
+    <td align="center"><img src="docs/media/deadlift.gif" width="230" alt="Deadlift rendered from .posecode text"/><br/><sub><code>pelvis: hinge</code>, deadlift</sub></td>
+    <td align="center"><img src="docs/media/squat.gif" width="230" alt="Body-weight squat rendered from .posecode text"/><br/><sub><code>knees: flex 95</code>, squat</sub></td>
+    <td align="center"><img src="docs/media/lateral-raise.gif" width="230" alt="Lateral raise rendered from .posecode text"/><br/><sub><code>shoulders: abduct 90</code>, lateral raise</sub></td>
   </tr>
 </table>
 
@@ -26,13 +26,13 @@ as a tiny human-readable language that renders to an animated 3D figure in the b
 
 Ask an LLM to explain a push-up and it can only give you prose or a flat image.
 The model *knows* the biomechanics ("elbows flex, shoulders abduct on the
-descent") — it just has no syntax to express it that a renderer can read.
+descent"), it just has no syntax to express it that a renderer can read.
 Diffusion-based text-to-motion models exist, but they're heavy, expensive, and
 give you no fine control over the anatomical phases.
 
 Posecode takes the opposite, lightweight approach (see [the research](#background)):
 
-- The LLM writes a small **`.posecode`** document — semantic phases, not 3D matrices.
+- The LLM writes a small **`.posecode`** document: semantic phases, not 3D matrices.
 - A **client-side** parser + Three.js renderer animates it. Generation is a
   fraction of a cent of text; rendering runs at 60fps on a phone.
 - Every angle is **hard-clamped to a healthy range of motion**, so a model
@@ -71,17 +71,17 @@ npm run eval     # fidelity scorecard: geometric invariants over every example
 
 In the playground: pick an example, watch it animate, edit the text live, and
 hit **Copy LLM prompt** to get a system prompt that teaches ChatGPT/Claude to
-write Posecode for you — or wire up the [MCP server](packages/posecode-mcp) so
+write Posecode for you, or wire up the [MCP server](packages/posecode-mcp) so
 your agent authors, validates, and renders movements natively.
 
 ## How Posecode stays honest
 
 Two safety layers ship with the language:
 
-- **ROM clamping** — every angle is hard-clamped to healthy range-of-motion
+- **ROM clamping**: every angle is hard-clamped to healthy range-of-motion
   tables before rendering; a hallucinated `knee: flex 200` renders at its
   ceiling with a warning, never an impossible joint.
-- **Fidelity evals** — [`posecode-eval`](packages/posecode-eval) re-runs the
+- **Fidelity evals**: [`posecode-eval`](packages/posecode-eval) re-runs the
   real parser → FK → ground-lock pipeline headlessly and scores geometric
   invariants ("a deadlift pitches the torso ≥ 50° with vertical shins"). Every
   example must pass every invariant in CI.
@@ -93,11 +93,11 @@ Two safety layers ship with the language:
 | [`posecode-parser`](packages/posecode-parser) | `.posecode` text → validated, ROM-clamped IR. Pure TypeScript, framework-agnostic. |
 | [`posecode-render`](packages/posecode-render) | IR → animated low-poly mannequin (Three.js), forward kinematics + ground-lock CCD IK. |
 | [`posecode-share`](packages/posecode-share) | Encode a `.posecode` doc to a URL-safe token so a movement travels as a link. Pure, dependency-free. |
-| [`posecode-mcp`](packages/posecode-mcp) | MCP server: lets an LLM agent author, ROM-validate, and get a render link for a movement — natively. |
+| [`posecode-mcp`](packages/posecode-mcp) | MCP server: lets an LLM agent author, ROM-validate, and get a render link for a movement, natively. |
 | [`posecode-eval`](packages/posecode-eval) | Fidelity harness: headless kinematic probing + biomechanical invariant scoring. |
 | [`playground`](playground) | Live editor + 3D viewport + warnings + the LLM prompt + shareable links. |
 
-The protocol and both libraries are **MIT-licensed** — the open core. See
+The protocol and both libraries are **MIT-licensed**: the open core. See
 [`spec/SPEC.md`](spec/SPEC.md) for the full language and
 [`spec/llm-authoring.md`](spec/llm-authoring.md) for the authoring prompt.
 For where Posecode spreads fastest and the per-domain go-to-market plan, see

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,59 +1,59 @@
-# Posecode — domains & roadmap
+# Posecode: domains & roadmap
 
 Posecode's vision is broad: **describe any single-person movement as text and render it
 safely in 3D.** The *protocol* is general; the *current renderer* is deliberately
 scoped (one figure, forward kinematics, ground-locked hands/feet, no props). This
 doc maps the domains Posecode can serve, what already works, and what each remaining
-domain needs — so contributions land where they unlock the most.
+domain needs, so contributions land where they unlock the most.
 
 ## Where Posecode fits
 
 | Domain | Example uses | Status |
 | --- | --- | --- |
-| **Physiotherapy / rehab** | Range-of-motion demos, home-exercise programs, post-op protocols, cervical/shoulder mobility | ✅ Strong fit today — the ROM safety clamp is a clinical feature. Many moves render now; equipment (bands, balls) is future. |
+| **Physiotherapy / rehab** | Range-of-motion demos, home-exercise programs, post-op protocols, cervical/shoulder mobility | ✅ Strong fit today: the ROM safety clamp is a clinical feature. Many moves render now; equipment (bands, balls) is future. |
 | **Ergonomics / desk & posture** | Posture resets, seated/standing stretch breaks, "do this every hour" prompts | ✅ Works today for standing variants; true *seated* needs a chair prop (below). |
 | **Yoga & mobility** | Standing poses (chair, side bend, twist), flows, mobility drills | ✅ Standing poses work; floor/inversion/lying poses need lying base poses + a mat. |
-| **Movement education / anatomy** | Demonstrate joint actions ("what is shoulder abduction?"), biomechanics teaching | ✅ Excellent fit — single-joint demos are exactly what the rig does. |
+| **Movement education / anatomy** | Demonstrate joint actions ("what is shoulder abduction?"), biomechanics teaching | ✅ Excellent fit: single-joint demos are exactly what the rig does. |
 | **Fitness / strength** | Body-weight and free-form movement coaching | ✅ Core today (squat, curl, raise). Barbell/dumbbell/machine work needs props + grip. |
-| **Functional / elderly care** | Sit-to-stand, balance, gentle ROM, fall-prevention drills | 🟡 Partial — sit-to-stand works; reaching/balance need reach-IK + props. |
-| **Sports technique** | Golf swing, tennis serve, throwing, kicking | 🟡 Partial — needs trunk rotation fidelity, weight shift, and implements (club/racket/ball). |
+| **Functional / elderly care** | Sit-to-stand, balance, gentle ROM, fall-prevention drills | 🟡 Partial: sit-to-stand works; reaching/balance need reach-IK + props. |
+| **Sports technique** | Golf swing, tennis serve, throwing, kicking | 🟡 Partial: needs trunk rotation fidelity, weight shift, and implements (club/racket/ball). |
 | **Dance / choreography** | Notating sequences, port de bras, phrases that turn & travel | ✅ Phrases, port de bras, pirouettes, and traveling combos (box-step, grapevine, chassé) work via `turn`/`travel`; partner work is future. |
 | **Martial arts** | Stances, strikes, basic forms | 🟡 Stances/strikes partly work; contact and weapons are future. |
-| **Sign language / gesture** | Finger-spelling, signs, expressive gesture | 🟡 Partial — single-DOF finger curls render visibly (fist, pinch, wave, rough finger-spelling); exact sign language needs multi-joint fingers + wrist orientation. |
+| **Sign language / gesture** | Finger-spelling, signs, expressive gesture | 🟡 Partial: single-DOF finger curls render visibly (fist, pinch, wave, rough finger-spelling); exact sign language needs multi-joint fingers + wrist orientation. |
 
 ## Engine capabilities that widen the scope
 
 These are the unlocks, roughly in order of leverage:
 
-1. ~~**Hip / waist hinge primitive**~~ — ✅ **shipped (v0.1).** `pelvis: hinge <deg>`
+1. ~~**Hip / waist hinge primitive**~~: ✅ **shipped (v0.1).** `pelvis: hinge <deg>`
    tips the torso forward over the hips while the legs stay planted (the renderer
    counter-rotates the hips). Powers `deadlift`, `bent-over-row`, `good-morning`,
    and `bow`. Next: hinge with a loaded-bar prop.
-2. ~~**Reach-IK (reach a world target)**~~ — ✅ **shipped, now ROM-constrained.**
+2. ~~**Reach-IK (reach a world target)**~~: ✅ **shipped, now ROM-constrained.**
    `reach: <effector> <target>` drives a hand/foot to a body landmark, the
    `floor`, or a prop anchor via CCD. Powers `touch-toes`, `cross-body-reach`,
    `seated-forward-fold`, and prop grips. The solve clamps every chain joint
-   into its Range-of-Motion box each iteration — solved angles obey the same
-   hard limits as authored ones — and `hands` / `feet` reach or pin both sides
+   into its Range-of-Motion box each iteration; solved angles obey the same
+   hard limits as authored ones, and `hands` / `feet` reach or pin both sides
    in one line. Next: two-bone analytic solve for straighter elbows/knees.
-3. ~~**Scene props with contact anchors**~~ — ✅ **shipped (starter set).** `prop
+3. ~~**Scene props with contact anchors**~~: ✅ **shipped (starter set).** `prop
    chair|wall|bar` adds a scene object with named anchors (`seat`, `wall`, `bar`).
    Powers `sit-to-stand`, `box-squat`, `wall-sit`, `dead-hang`, `hanging-knee-raise`.
    Next: more props (bench, rings, bands), load cues, anchor-aware ground-lock.
-4. ~~**Lying & seated base poses**~~ — ✅ **shipped.** `supine | prone | seated`
+4. ~~**Lying & seated base poses**~~: ✅ **shipped.** `supine | prone | seated`
    start poses (grounded by a bounding-box drop). Powers `glute-bridge`,
    `dead-bug`, `cobra`, `seated-forward-fold`. Next: quadruped + chair-seated.
-5. ~~**Hand / finger articulation**~~ — ✅ **shipped (single-DOF).** Per-finger
+5. ~~**Hand / finger articulation**~~: ✅ **shipped (single-DOF).** Per-finger
    curl bones + `fingers` group. Powers `make-a-fist`, `pinch-grip`, `hand-wave`,
    `finger-spell-demo`. Next: multi-joint fingers for accurate sign language.
-6. ~~**Spatial choreography (turn & travel)**~~ — ✅ **shipped.** `turn: <deg>`
+6. ~~**Spatial choreography (turn & travel)**~~: ✅ **shipped.** `turn: <deg>`
    rotates the figure's facing and `travel: <x> <z>` moves it across the floor,
    both absolute + carried across phases and returning home on the loop wrap.
    Powers `pirouette`, `box-step`, `grapevine`, `waltz-box`, `chasse`,
-   `walk-cycle`, `quarter-turns` — pirouettes, traveling combos, and gait.
+   `walk-cycle`, `quarter-turns`: pirouettes, traveling combos, and gait.
    Standing poses only. Next: footstep-locked travel (true gait), motion
    aliveness (velocity-continuous flow + weight shift).
-7. **Two-person + collision** — partner stretches, assisted rehab, contact sports
+7. **Two-person + collision**: partner stretches, assisted rehab, contact sports
    (still deferred in the spec).
 
 ## Prop / equipment library (future)
@@ -72,17 +72,17 @@ Each prop is a small scene object + an anchor type; movements then reference it
 | **Resistance band** | Band pull-aparts, banded rehab, mobility with tension |
 | **Dumbbell / barbell / kettlebell** | Loaded strength patterns (needs grip + load cues) |
 | **Ball (stability / medicine)** | Core work, balance, throws |
-| **Parallettes / dip station** | ✅ Dip bars shipped (`prop dip-bars` — triceps dips). Still future: L-sits, push-up variations at height |
+| **Parallettes / dip station** | ✅ Dip bars shipped (`prop dip-bars`, triceps dips). Still future: L-sits, push-up variations at height |
 | **Foam roller** | Self-myofascial release, mobility drills |
 
 ## Current limitations (honest)
 
 - One figure only; partner work and collision are still deferred.
-- A **starter** prop set (chair / wall / bar / box / dip bars) — no bench,
+- A **starter** prop set (chair / wall / bar / box / dip bars): no bench,
   rings, bands, or loaded implements yet, and props sit at fixed default
   placements.
 - Props are visual + reach anchors (no physical sit/lean solve).
-- Fingers are **single-DOF** curls — good for grip and rough gesture, not exact
+- Fingers are **single-DOF** curls, good for grip and rough gesture, not exact
   sign language. The head has no facial articulation.
 
 > Range-of-motion values are general literature data, not medical advice.

--- a/VERCEL_AGENTS.md
+++ b/VERCEL_AGENTS.md
@@ -1,4 +1,4 @@
-# Vercel Plugin — AI Agent Instructions
+# Vercel Plugin: AI Agent Instructions
 
 > Drop this file into any GitHub repo. AI coding agents (Claude Code, Codex, Cursor, Copilot, Grok Build) will pick it up automatically.
 
@@ -22,25 +22,25 @@ Requires Node.js 18+ and Bun. After install, session context is injected automat
 
 ## Key skills (invoke on demand)
 
-- `nextjs` — App Router, Server Components, Server Actions, rendering strategies
-- `ai-sdk` — AI SDK v6: streaming, tool calling, agents, MCP, embeddings
-- `ai-gateway` — Unified API to 100+ models with failover and cost tracking
-- `vercel-functions` — Serverless, Edge, Fluid Compute, streaming, Cron Jobs
-- `vercel-storage` — Blob, Edge Config, Neon Postgres, Upstash Redis
-- `deployments-cicd` — Deploy, promote, rollback, `--prebuilt`, CI config
-- `env-vars` — `.env` files, `vercel env`, OIDC tokens
-- `routing-middleware` — Rewrites, redirects, personalization (Node.js/Edge/Bun)
-- `runtime-cache` — Per-region KV cache with tag-based invalidation
-- `shadcn` — shadcn/ui CLI, components, theming, Tailwind integration
-- `workflow` — Durable execution, DurableAgent, steps, pause/resume
-- `vercel-sandbox` — Ephemeral VMs for running untrusted/AI-generated code
-- `verification` — Browser, API, data, and response flow verification
+- `nextjs`: App Router, Server Components, Server Actions, rendering strategies
+- `ai-sdk`: AI SDK v6: streaming, tool calling, agents, MCP, embeddings
+- `ai-gateway`: Unified API to 100+ models with failover and cost tracking
+- `vercel-functions`: Serverless, Edge, Fluid Compute, streaming, Cron Jobs
+- `vercel-storage`: Blob, Edge Config, Neon Postgres, Upstash Redis
+- `deployments-cicd`: Deploy, promote, rollback, `--prebuilt`, CI config
+- `env-vars`: `.env` files, `vercel env`, OIDC tokens
+- `routing-middleware`: Rewrites, redirects, personalization (Node.js/Edge/Bun)
+- `runtime-cache`: Per-region KV cache with tag-based invalidation
+- `shadcn`: shadcn/ui CLI, components, theming, Tailwind integration
+- `workflow`: Durable execution, DurableAgent, steps, pause/resume
+- `vercel-sandbox`: Ephemeral VMs for running untrusted/AI-generated code
+- `verification`: Browser, API, data, and response flow verification
 
 ## Specialist agents
 
-- `deployment-expert` — CI/CD, deploy strategies, environment variables, rollbacks
-- `performance-optimizer` — Core Web Vitals, caching, rendering, asset optimization
-- `ai-architect` — AI app design, model selection, streaming, MCP integration
+- `deployment-expert`: CI/CD, deploy strategies, environment variables, rollbacks
+- `performance-optimizer`: Core Web Vitals, caching, rendering, asset optimization
+- `ai-architect`: AI app design, model selection, streaming, MCP integration
 
 ## Platform defaults to assume
 

--- a/docs/coverage-gap.md
+++ b/docs/coverage-gap.md
@@ -1,9 +1,9 @@
-# Movement coverage — gap analysis
+# Movement coverage: gap analysis
 
 > Benchmarks Posecode's curated library against a standard fitness taxonomy
 > (body-part × equipment × target muscle), the structure popularised by public
 > exercise datasets. **We use those datasets only as a yardstick for *coverage and
-> taxonomy* — never their copyrighted media, instructions, or records.** Every
+> taxonomy*, never their copyrighted media, instructions, or records.** Every
 > Posecode movement is authored from scratch and ROM-validated.
 
 The point of this doc: find the holes in our library that the **current engine can
@@ -15,7 +15,7 @@ Renderable: **body-weight** movements, plus our props **chair / wall / bar**, on
 single FK figure with ground-lock, reach-IK, hip-hinge, lying/seated poses, and a
 single-DOF hand rig.
 
-Not yet renderable (so *not* counted as gaps — they're roadmap items): dumbbell /
+Not yet renderable (so *not* counted as gaps: they're roadmap items): dumbbell /
 barbell / cable / machine / band work (needs load + grip-to-implement), and
 anything needing a second person. In a typical exercise dataset these are the
 majority; the **body-weight subset (~25%)** is our addressable universe.
@@ -28,7 +28,7 @@ majority; the **body-weight subset (~25%)** is our addressable universe.
 | Core / waist | dead-bug, glute-bridge, hanging-knee-raise, spinal-twist, side-bend, cross-body-reach | ~6 | **No crunch / plank / leg-raise / climber** |
 | Shoulders | lateral-raise, shoulder-flexion, shoulder-abduction, shoulder-rolls, overhead-reach, arm-circles, port-de-bras | ~7 | Good |
 | Back | bent-over-row, deadlift, good-morning, cobra, dead-hang | ~5 | **No superman / extension holds** |
-| Chest | chest-opener (stretch only) | 1 | **Weak — push-up was pulled from the catalogue; still the obvious gap-filler once chest coverage is revisited** |
+| Chest | chest-opener (stretch only) | 1 | **Weak: push-up was pulled from the catalogue; still the obvious gap-filler once chest coverage is revisited** |
 | Upper arms | biceps-curl, elbow-forearm | 2 | **No triceps work** |
 | Lower legs | heel-raises, relevé | 2 | Thin |
 | Neck | neck-rotation, neck-side-stretch | 2 | Fine for scope |
@@ -39,36 +39,36 @@ majority; the **body-weight subset (~25%)** is our addressable universe.
 
 Ordered by gap size × how cleanly the engine renders it:
 
-1. **Core** — `plank-hold`, `mountain-climber` (plank pose), `crunch`,
+1. **Core**: `plank-hold`, `mountain-climber` (plank pose), `crunch`,
    `bicycle-crunch`, `supine-leg-raise` (supine pose). Highest-value, cleanest.
-2. **Chest** — still open; `push-up` was authored and then pulled from the
+2. **Chest**: still open; `push-up` was authored and then pulled from the
    catalogue (see note above), so this gap remains.
-3. **Back** — `superman` (prone pose).
-4. **Upper legs** — `forward-lunge` (FK split stance, feet leveled).
-5. **Lower legs** — `single-leg-calf-raise`.
-6. **Conditioning / mobility** — `jumping-jacks`, `standing-quad-stretch`
+3. **Back**: `superman` (prone pose).
+4. **Upper legs**: `forward-lunge` (FK split stance, feet leveled).
+5. **Lower legs**: `single-leg-calf-raise`.
+6. **Conditioning / mobility**: `jumping-jacks`, `standing-quad-stretch`
    (single-leg + reach-IK).
 
-These ~10 movements roughly **double our chest/core/back coverage** — all on
+These ~10 movements roughly **double our chest/core/back coverage**: all on
 today's engine, no new primitives required.
 
 **Front box prop (added):** a `prop box` placed in front of the figure powers
-`box-step-taps` (the lead foot taps the box top — verified landing on the anchor).
+`box-step-taps` (the lead foot taps the box top, verified landing on the anchor).
 
-**Contact pins (added) — the root-translation primitive.** `pin: <effector>
+**Contact pins (added): the root-translation primitive.** `pin: <effector>
 <anchor>` translates the whole body so a pinned hand/foot stays on its anchor
 while the limbs work, which is exactly the vertical body motion that was missing.
 This unlocked, all verified through the real rig:
 
-- `pull-up` — hang from the bar (feet ~0.38 m off the floor), elbows flex → pelvis
+- `pull-up`: hang from the bar (feet ~0.38 m off the floor), elbows flex → pelvis
   climbs ~0.34 m toward the bar.
-- `step-up` — lead foot pinned to the box top; the leg straightens → the body
+- `step-up`: lead foot pinned to the box top; the leg straightens → the body
   rises ~0.32 m onto the box, trailing foot lifting off.
-- `triceps-dips` — hands pinned to the chair seat; elbows bend → hips lower.
-- `dead-hang` / `hanging-knee-raise` — now genuinely suspended from the bar.
+- `triceps-dips`: hands pinned to the chair seat; elbows bend → hips lower.
+- `dead-hang` / `hanging-knee-raise`: now genuinely suspended from the bar.
 
 **Still deferred:** free-flight moves (jumps, burpees) where the body leaves *all*
-contacts — those want an authored whole-body `lift` channel (no anchor), a small
+contacts, those want an authored whole-body `lift` channel (no anchor), a small
 follow-on to the pin work.
 
 ## Metadata gap (drives the catalogue work)
@@ -76,5 +76,5 @@ follow-on to the pin work.
 A real exercise record carries `body-part, equipment, primary target, secondary
 muscles, difficulty`. Posecode presets carried only `id, label, domain`. We now add
 `bodyPart / target / equipment / difficulty` to every preset and a **filterable
-gallery**, so the library is searchable like a proper exercise explorer — see
+gallery**, so the library is searchable like a proper exercise explorer, see
 `playground/src/presets.ts` and the filter row in the playground.

--- a/docs/market-research.md
+++ b/docs/market-research.md
@@ -1,4 +1,4 @@
-# Posecode — market research & go-to-market
+# Posecode: market research & go-to-market
 
 > Where Posecode spreads fastest, who pulls hardest, and which engine unlock opens
 > which locked domain. Companion to [`../ROADMAP.md`](../ROADMAP.md) (engine
@@ -9,7 +9,7 @@
 
 Posecode is **"Mermaid for human movement."** A person describes a movement in
 words; an LLM writes a short `.posecode` document; the browser parses it, clamps it
-to a safe range of motion, and renders an animated 3D mannequin — producing a
+to a safe range of motion, and renders an animated 3D mannequin, producing a
 **shareable URL**. The loop is:
 
 > **ask an LLM for a movement → it renders → share the link.**
@@ -18,7 +18,7 @@ This is structurally different from video. A `.posecode` doc is **editable text*
 an LLM can generate it, a human can tweak one angle, a clinician can fork it, and
 it diffs in version control. Diffusion/video models hallucinate anatomy and can't
 be safely constrained; Posecode's ROM clamp is a *correctness* feature, not a filter.
-Text is also how LLMs natively "think" about structure — so authoring is reliable
+Text is also how LLMs natively "think" about structure, so authoring is reliable
 and improves as models improve.
 
 ### Why it can spread
@@ -28,10 +28,10 @@ and improves as models improve.
 - **Shareable by construction.** Every movement is a URL ([`posecode-share`](../packages/posecode-share)).
   A link is the most viral object on the internet.
 - **Agent-native.** The [`posecode-mcp`](../packages/posecode-mcp) server lets Claude/
-  ChatGPT author, validate, and return a render link *inside the chat* — the
+  ChatGPT author, validate, and return a render link *inside the chat*: the
   movement appears where the user already is.
 - **Safe to trust.** Clinical ROM limits mean shared links can't depict unsafe
-  joint angles — important for the health-adjacent buyers below.
+  joint angles: important for the health-adjacent buyers below.
 
 ## 2. How we scored the domains
 
@@ -44,13 +44,13 @@ Each domain is rated on four axes:
 | **Virality** | How naturally does output get shared, embedded, or re-prompted? |
 | **LLM-authorability** | Can a model reliably write correct docs with little context? |
 
-The four domains below score highest on **engine-fit × authorability** — they
+The four domains below score highest on **engine-fit × authorability**: they
 work *today*, so the catalog and the viral loop compound now rather than waiting
 on the roadmap.
 
 ## 3. Target domains (ship now)
 
-### 3a. Anatomy & movement education — *top of funnel*
+### 3a. Anatomy & movement education: *top of funnel*
 
 - **Customer:** anatomy/kinesiology students & instructors, PT/OT/med students,
   personal-trainer certifications, biology teachers, curious people.
@@ -61,7 +61,7 @@ on the roadmap.
   teachers paste links into slides/LMS; students re-prompt for the next joint.
 - **Ships:** `shoulder-abduction-demo`, `hip-flexion-demo`, `knee-flexion-demo`,
   `spine-rotation-demo`, `elbow-flexion-pronation`.
-- **Engine-fit:** ★★★★★ — single-joint ROM demos are *exactly* what the rig does.
+- **Engine-fit:** ★★★★★, single-joint ROM demos are *exactly* what the rig does.
 
 ### 3b. Physiotherapy & rehab
 
@@ -74,7 +74,7 @@ on the roadmap.
 - **Ships:** `heel-raises`, `standing-hamstring-curl`, `hip-abduction`,
   `good-morning` (back-health hinge), plus existing `neck-rotation`,
   `shoulder-stretch`.
-- **Engine-fit:** ★★★★☆ — the ROM clamp is a clinical feature; bands/balls and
+- **Engine-fit:** ★★★★☆, the ROM clamp is a clinical feature; bands/balls and
   lying poses are future (see roadmap).
 
 ### 3c. Desk & workplace wellness
@@ -87,23 +87,23 @@ on the roadmap.
   break" habit; embeds on internal wikis.
 - **Ships:** `shoulder-rolls`, `neck-side-stretch`, `chest-opener`,
   `overhead-reach-reset`, plus existing `posture-reset`, `spinal-twist`.
-- **Engine-fit:** ★★★★☆ — standing variants render today; true *seated* needs a
+- **Engine-fit:** ★★★★☆, standing variants render today; true *seated* needs a
   chair prop.
 
-### 3d. Sports, martial arts & **dance** — *flagship*
+### 3d. Sports, martial arts & **dance**: *flagship*
 
 - **Customer:** coaches, dancers/choreographers, martial-arts instructors,
   general athletes warming up.
 - **Aha use case (sports/MA):** stances, strikes, and warm-up drills as
-  short, snappy, shareable clips — `front-kick`, `jab-cross`, `horse-stance`,
+  short, snappy, shareable clips: `front-kick`, `jab-cross`, `horse-stance`,
   `bow`, `arm-circles`, `high-knee-march`.
 
-#### Dance / choreography — the flagship bet
+#### Dance / choreography: the flagship bet
 
 Dance is where the *editable-text* thesis is most magical: **you describe the
-movement in your head and watch it appear** — then nudge a beat, swap an arm
+movement in your head and watch it appear**, then nudge a beat, swap an arm
 position, extend the phrase, and re-share. It is inherently sequential,
-expressive, and social — exactly the content people share.
+expressive, and social: exactly the content people share.
 
 - **Customer:** choreographers drafting and notating phrases, dance teachers,
   students learning vocabulary, social dancers.
@@ -115,14 +115,14 @@ expressive, and social — exactly the content people share.
   `dance-phrase` centerpiece.
 - **Engine-fit:** ★★★☆☆ today (turnout, plié, relevé, port de bras all render);
   precise foot placement, traveling steps, and partner work are future.
-- **Long game:** a **shareable, LLM-authorable choreography notation** — Labanotation
+- **Long game:** a **shareable, LLM-authorable choreography notation**: Labanotation
   was never going to be typed into a chat box; a `.posecode` phrase is. If Posecode
   becomes the way people sketch and pass around movement, dance is the wedge.
 
 ## 4. Spread mechanics
 
 - **MCP inside the assistant.** [`posecode-mcp`](../packages/posecode-mcp) puts authoring +
-  a render link directly in Claude/ChatGPT — distribution rides on assistants we
+  a render link directly in Claude/ChatGPT: distribution rides on assistants we
   don't have to build an audience for.
 - **Links as the unit.** [`posecode-share`](../packages/posecode-share) makes every
   movement a URL; links are forwarded, bookmarked, and embedded.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -2,12 +2,12 @@
 
 Language support for the **Posecode** (`.posecode`) kinematic motion DSL:
 
-- **Syntax highlighting** (TextMate grammar) — keywords, kinds, joints, actions, easings, strings, numbers.
-- **Diagnostics** — parse errors and **range-of-motion safety clamps** as you type (e.g. `knees: flex 200° → clamped to 144°`).
-- **Completion** — context-aware: kinds after `posecode`, joints at line start, actions after `<joint>:`, easings in a `step` header, poses after `pose start =`, effectors after `ground-lock:`.
-- **Hover** — the safe ROM range for a joint + action, and short docs for keywords.
+- **Syntax highlighting** (TextMate grammar): keywords, kinds, joints, actions, easings, strings, numbers.
+- **Diagnostics**: parse errors and **range-of-motion safety clamps** as you type (e.g. `knees: flex 200° → clamped to 144°`).
+- **Completion** (context-aware): kinds after `posecode`, joints at line start, actions after `<joint>:`, easings in a `step` header, poses after `pose start =`, effectors after `ground-lock:`.
+- **Hover**: the safe ROM range for a joint + action, and short docs for keywords.
 
-The smart features are provided by [`posecode-lsp`](../../packages/posecode-lsp), which shares its language logic ([`posecode-language`](../../packages/posecode-language)) with the web playground — so the editor and the playground always agree.
+The smart features are provided by [`posecode-lsp`](../../packages/posecode-lsp), which shares its language logic ([`posecode-language`](../../packages/posecode-language)) with the web playground, so the editor and the playground always agree.
 
 ## Develop / run locally
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "posecode-vscode",
   "private": true,
   "displayName": "Posecode",
-  "description": "Language support for the Posecode (.posecode) kinematic motion DSL — syntax highlighting, range-of-motion diagnostics, completion, and hover.",
+  "description": "Language support for the Posecode (.posecode) kinematic motion DSL: syntax highlighting, range-of-motion diagnostics, completion, and hover.",
   "version": "0.1.0",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "posecode-monorepo",
   "version": "0.1.0",
   "private": true,
-  "description": "Posecode — a kinematic motion protocol for LLMs. Describe 3D human movement as text; render it in the browser.",
+  "description": "Posecode: a kinematic motion protocol for LLMs. Describe 3D human movement as text; render it in the browser.",
   "license": "MIT",
   "workspaces": [
     "packages/*",

--- a/packages/posecode-embed/README.md
+++ b/packages/posecode-embed/README.md
@@ -3,7 +3,7 @@
 **Embed a live 3D Posecode movement anywhere with one `<script>` tag.**
 
 `posecode-embed` ships a framework-free `<posecode-player>` web component. Drop
-it into a blog post, docs page, physio program, or an LLM chat UI — it renders
+it into a blog post, docs page, physio program, or an LLM chat UI, and it renders
 the movement as an animated 3D figure, right where a share link would have gone.
 
 ## Quick start (CDN, no build step)
@@ -17,7 +17,7 @@ the movement as an animated 3D figure, right where a share link would have gone.
 <!-- 2. From a URL to a .posecode file -->
 <posecode-player src="/movements/squat.posecode"></posecode-player>
 
-<!-- 3. From inline text — reads like the language itself -->
+<!-- 3. From inline text: reads like the language itself -->
 <posecode-player>
 posecode exercise "Lateral raise"
   rig humanoid
@@ -56,9 +56,9 @@ definePosecodePlayer(); // idempotent
 
 | Attribute | Default | Description |
 | --- | --- | --- |
-| `doc` | — | A `posecode-share` token (highest precedence). |
-| `src` | — | URL of a `.posecode` file to fetch. |
-| *(inline text)* | — | The element's text content, used if `doc`/`src` are absent. |
+| `doc` | n/a | A `posecode-share` token (highest precedence). |
+| `src` | n/a | URL of a `.posecode` file to fetch. |
+| *(inline text)* | n/a | The element's text content, used if `doc`/`src` are absent. |
 | `autoplay` | `true` | Play as soon as the movement loads. |
 | `loop` | `true` | Loop the timeline. |
 | `controls` | `true` | Show the play/pause bar. |

--- a/packages/posecode-embed/src/element.ts
+++ b/packages/posecode-embed/src/element.ts
@@ -1,11 +1,11 @@
 /**
- * `<posecode-player>` — a self-contained custom element that renders a Posecode
+ * `<posecode-player>`: a self-contained custom element that renders a Posecode
  * movement as a live 3D figure. Drop it on any page; give it a movement via a
  * `doc` token, a `src` URL, or inline text.
  *
  * Design notes:
  * - **Lazy boot.** three.js is heavy, so the WebGL viewer is created only when
- *   the element scrolls into view (IntersectionObserver) — many embeds on one
+ *   the element scrolls into view (IntersectionObserver): many embeds on one
  *   page stay cheap until seen.
  * - **Shadow DOM.** Markup + styles are isolated from the host page.
  * - **Accessible & polite.** Honors `prefers-reduced-motion` (no autoplay, no
@@ -49,7 +49,7 @@ export class PosecodePlayerElement extends HTMLElement {
     // Capture inline text BEFORE we replace the light DOM with shadow markup.
     this.#source = this.textContent ?? "";
     this.#renderChrome();
-    // Boot immediately UNLESS the element is measurably off-screen — in which
+    // Boot immediately UNLESS the element is measurably off-screen, in which
     // case defer the heavy renderer until it scrolls into view. The bias is
     // toward booting: an embed must never stay blank because we couldn't
     // measure the viewport (e.g. innerHeight reported as 0) or because the

--- a/packages/posecode-embed/src/index.ts
+++ b/packages/posecode-embed/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-embed — public API.
+ * posecode-embed: public API.
  *
  * Importing this module in a browser auto-registers `<posecode-player>`, so the
  * common case is zero-config:
@@ -31,5 +31,5 @@ export function definePosecodePlayer(): void {
   customElements.define(PosecodePlayerElement.tagName, PosecodePlayerElement);
 }
 
-// Auto-register on import in a browser — the batteries-included default.
+// Auto-register on import in a browser: the batteries-included default.
 definePosecodePlayer();

--- a/packages/posecode-embed/src/options.ts
+++ b/packages/posecode-embed/src/options.ts
@@ -3,7 +3,7 @@
  *
  * Pure and DOM-free so it is unit-testable in node: the element hands us a
  * plain record of its attribute values. Boolean attributes follow a friendly
- * variant of HTML semantics — present means true, but an explicit `"false"`
+ * variant of HTML semantics: present means true, but an explicit `"false"`
  * (or `"0"` / `"no"`) turns them off, which reads better in hand-written embeds.
  */
 

--- a/packages/posecode-embed/src/source.ts
+++ b/packages/posecode-embed/src/source.ts
@@ -2,12 +2,12 @@
  * Resolve a `<posecode-player>`'s movement source from its three input modes,
  * in precedence order:
  *
- *   1. `doc="<token>"`   — a posecode-share token (how permalinks travel)
- *   2. `src="<url>"`     — fetch a `.posecode` file
- *   3. inline text       — the element's own text content
+ *   1. `doc="<token>"`: a posecode-share token (how permalinks travel)
+ *   2. `src="<url>"`: fetch a `.posecode` file
+ *   3. inline text: the element's own text content
  *
  * DOM-free: the element passes a plain descriptor, so this is unit-testable in
- * node. Never throws — every failure comes back as `{ ok: false, error }` so
+ * node. Never throws: every failure comes back as `{ ok: false, error }` so
  * the element can render a friendly message instead of a blank canvas.
  */
 
@@ -59,7 +59,7 @@ export async function resolveSource(
 
   return {
     ok: false,
-    error: "No movement to render — set a doc token, a src URL, or inline text.",
+    error: "No movement to render: set a doc token, a src URL, or inline text.",
   };
 }
 

--- a/packages/posecode-embed/src/styles.ts
+++ b/packages/posecode-embed/src/styles.ts
@@ -1,6 +1,6 @@
 /**
  * Shadow-DOM styles for the player. Scoped to the shadow root so an embed can
- * never leak styles into — or inherit surprises from — the host page. Colors
+ * never leak styles into (or inherit surprises from) the host page. Colors
  * mirror the playground's studio-dark + lime theme but are self-contained.
  */
 

--- a/packages/posecode-embed/test/options.test.ts
+++ b/packages/posecode-embed/test/options.test.ts
@@ -10,7 +10,7 @@ describe("parseOptions", () => {
     // HTML boolean attrs: present (even empty string) is true, absent is false.
     const o = parseOptions({ controls: "", autorotate: "false" });
     expect(o.controls).toBe(true);
-    // A literal "false" value still disables — friendlier than pure HTML semantics.
+    // A literal "false" value still disables: friendlier than pure HTML semantics.
     expect(o.autoRotate).toBe(false);
   });
 

--- a/packages/posecode-eval/src/checks.ts
+++ b/packages/posecode-eval/src/checks.ts
@@ -1,5 +1,5 @@
 /**
- * Invariant checks — the "does it look like the movement it claims to be"
+ * Invariant checks: the "does it look like the movement it claims to be"
  * layer. Generic checks apply to every document; movement checks encode the
  * biomechanical signature of specific canonical movements (verified against
  * the playground render).
@@ -73,7 +73,7 @@ export function genericChecks(result: ProbeResult): CheckOutcome[] {
   for (const p of result.phases) {
     // The one universal contact invariant: nothing sinks through the floor.
     // (A stricter "declared effector is planted" check isn't portable across
-    // the library — the renderer grounds the visible MESH, so a planted foot
+    // the library: the renderer grounds the visible MESH, so a planted foot
     // leaves its ankle BONE ~0.04m up and a supporting hand leaves the wrist
     // bone higher still; stepping/travel movements lift feet by design.)
     out.push({
@@ -92,7 +92,7 @@ export function genericChecks(result: ProbeResult): CheckOutcome[] {
  */
 export const MOVEMENT_CHECKS: MovementChecks[] = [
   {
-    // `pelvis: hinge` — torso tips forward over vertical legs (deadlift phases
+    // `pelvis: hinge`: torso tips forward over vertical legs (deadlift phases
     // "Lower"/"Lift"). Regressing the hinge into a leg-swing or a backward
     // bend fails these loudly.
     movement: "deadlift",

--- a/packages/posecode-eval/src/generator.ts
+++ b/packages/posecode-eval/src/generator.ts
@@ -1,7 +1,7 @@
 /**
  * Movement sources for the harness.
  *
- * The fixture generator reads the canonical `spec/examples` — the regression
+ * The fixture generator reads the canonical `spec/examples`: the regression
  * baseline. LLM generators implement the same interface so "ask model X for a
  * deadlift, score what it wrote" plugs straight into `runEval` (they need API
  * keys, so they live with the caller, not here).

--- a/packages/posecode-eval/src/index.ts
+++ b/packages/posecode-eval/src/index.ts
@@ -1,4 +1,4 @@
-/** posecode-eval — public API. */
+/** posecode-eval: public API. */
 
 export { probeMovement } from "./probe.js";
 export type { ProbeResult, PhasePose, Vec3 } from "./probe.js";

--- a/packages/posecode-eval/src/metrics.ts
+++ b/packages/posecode-eval/src/metrics.ts
@@ -1,5 +1,5 @@
 /**
- * Geometric metrics over probed bone positions — the vocabulary the
+ * Geometric metrics over probed bone positions: the vocabulary the
  * invariant checks are written in. All angles in degrees, distances in metres.
  */
 
@@ -74,7 +74,7 @@ export function lowestPoint(pose: PhasePose): number {
   return min;
 }
 
-/** Average height of the two ankles — 0 when the feet are planted. */
+/** Average height of the two ankles (0 when the feet are planted). */
 export function feetHeight(pose: PhasePose): number {
   return (heightOf(pose, "ankle_left") + heightOf(pose, "ankle_right")) / 2;
 }

--- a/packages/posecode-eval/src/probe.ts
+++ b/packages/posecode-eval/src/probe.ts
@@ -1,9 +1,9 @@
 /**
  * Headless kinematic probe.
  *
- * Runs a `.posecode` source through the REAL production pipeline — parser →
+ * Runs a `.posecode` source through the REAL production pipeline (parser →
  * timeline → mannequin FK → root choreography (yaw/travel) → ground-lock →
- * floor clamp — without a WebGL context (three.js scene-graph math is pure),
+ * floor clamp) without a WebGL context (three.js scene-graph math is pure),
  * and returns world-space bone positions at the end of every phase. This is
  * the ground truth the invariant checks score against.
  *

--- a/packages/posecode-language/package.json
+++ b/packages/posecode-language/package.json
@@ -1,7 +1,7 @@
 {
   "name": "posecode-language",
   "version": "0.1.0",
-  "description": "Editor language service for .posecode — diagnostics, completions, and hovers built on posecode-parser. Powers both the playground editor and the LSP.",
+  "description": "Editor language service for .posecode: diagnostics, completions, and hovers built on posecode-parser. Powers both the playground editor and the LSP.",
   "license": "MIT",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/posecode-language/src/diagnostics.ts
+++ b/packages/posecode-language/src/diagnostics.ts
@@ -32,7 +32,7 @@ export function getDiagnostics(text: string): Diagnostic[] {
     diagnostics.push({
       line: w.line,
       severity: "warning",
-      message: `${joint} ${w.action} ${w.requested}° exceeds range of motion — clamped to ${w.clamped}° (safe ${w.limit.min}–${w.limit.max}°)`,
+      message: `${joint} ${w.action} ${w.requested}° exceeds range of motion, clamped to ${w.clamped}° (safe ${w.limit.min}–${w.limit.max}°)`,
     });
   }
 

--- a/packages/posecode-language/src/hover.ts
+++ b/packages/posecode-language/src/hover.ts
@@ -58,7 +58,7 @@ export function getHover(
       const rom = romFor(bone, token);
       if (rom) {
         return md(
-          `**${boneType(bone)} · ${token}** — safe range **${rom.min}–${rom.max}°**. Angles beyond this are hard-clamped.`,
+          `**${boneType(bone)} · ${token}**: safe range **${rom.min}–${rom.max}°**. Angles beyond this are hard-clamped.`,
         );
       }
     }
@@ -70,7 +70,7 @@ export function getHover(
   }
 
   const keywordDoc = KEYWORD_DOCS[token];
-  if (keywordDoc) return md(`**${token}** — ${keywordDoc}`);
+  if (keywordDoc) return md(`**${token}**: ${keywordDoc}`);
   if (KINDS.includes(token)) return md(`Movement kind **${token}**.`);
   if (POSES.includes(token)) return md(`Start pose **${token}**.`);
   if ((EASINGS as readonly string[]).includes(token)) {

--- a/packages/posecode-language/src/index.ts
+++ b/packages/posecode-language/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-language — editor-agnostic language service for `.posecode`.
+ * posecode-language: editor-agnostic language service for `.posecode`.
  *
  * Pure functions over document text + a 0-based position. Consumed by the
  * playground's CodeMirror editor and by the LSP server, so both share one

--- a/packages/posecode-language/src/vocab.ts
+++ b/packages/posecode-language/src/vocab.ts
@@ -1,5 +1,5 @@
 /**
- * The Posecode vocabulary — the single source of truth editors complete against.
+ * The Posecode vocabulary: the single source of truth editors complete against.
  * Joint/action/easing lists come straight from the parser so they can never
  * drift from what the language actually accepts.
  */
@@ -17,7 +17,7 @@ export const POSES = ["neutral", "standing", "plank", "supine", "prone", "seated
 /** Effectors that can be ground-locked. */
 export const EFFECTORS = ["hands", "feet"];
 
-/** Reach/pin effectors (groups + per-side aliases) — sourced from the parser. */
+/** Reach/pin effectors (groups + per-side aliases), sourced from the parser. */
 export const REACH_EFFECTORS = EFFECTOR_NAMES;
 export const PROPS = ["chair", "wall", "bar", "box", "dip-bars"];
 
@@ -29,19 +29,19 @@ export const CHILD_KEYWORDS = ["ground-lock", "reach", "pin", "turn", "travel", 
 
 /** Short docs surfaced on hover and as completion detail. */
 export const KEYWORD_DOCS: Record<string, string> = {
-  posecode: 'Document header — `posecode <kind> "<name>"`.',
+  posecode: 'Document header: `posecode <kind> "<name>"`.',
   rig: "Selects the rig (currently `humanoid`).",
-  prop: "Adds a scene object — `prop chair | wall | bar | box | dip-bars`. Supplies reach/pin anchors.",
-  pose: "Sets the starting pose — `pose start = standing | neutral | plank | supine | prone | seated`.",
+  prop: "Adds a scene object: `prop chair | wall | bar | box | dip-bars`. Supplies reach/pin anchors.",
+  pose: "Sets the starting pose: `pose start = standing | neutral | plank | supine | prone | seated`.",
   start: "Used in `pose start = <pose>`.",
-  step: 'A movement phase — `step "<name>" <Ns> <easing>:`.',
+  step: 'A movement phase: `step "<name>" <Ns> <easing>:`.',
   repeat: "How many times the movement loops.",
   "ground-lock": "Pins effectors (hands / feet) to the floor for this phase.",
   reach:
-    "Drives an effector to a target via ROM-constrained IK — `reach: hand_left ankle_left`, `reach: hands floor`.",
-  pin: "Moves the body so an effector sits on an anchor — `pin: hands bar` (hang, pull up, step up, dip).",
-  turn: "Turns the figure to face a new direction — `turn: 360` (degrees, yaw about vertical). Absolute, carried across phases. Standing poses only.",
-  travel: "Moves the figure across the floor — `travel: 0.4 0` (world x z metres from the start spot). Absolute, carried across phases. Standing poses only.",
+    "Drives an effector to a target via ROM-constrained IK: `reach: hand_left ankle_left`, `reach: hands floor`.",
+  pin: "Moves the body so an effector sits on an anchor: `pin: hands bar` (hang, pull up, step up, dip).",
+  turn: "Turns the figure to face a new direction: `turn: 360` (degrees, yaw about vertical). Absolute, carried across phases. Standing poses only.",
+  travel: "Moves the figure across the floor: `travel: 0.4 0` (world x z metres from the start spot). Absolute, carried across phases. Standing poses only.",
   cue: "A short coaching cue shown while this phase plays.",
   hold: "Keep the joint at its neutral / rest angle.",
 };

--- a/packages/posecode-lsp/package.json
+++ b/packages/posecode-lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "posecode-lsp",
   "version": "0.1.0",
-  "description": "Language Server Protocol implementation for the Posecode (.posecode) DSL — diagnostics, completion, and hover, powered by posecode-language.",
+  "description": "Language Server Protocol implementation for the Posecode (.posecode) DSL: diagnostics, completion, and hover, powered by posecode-language.",
   "license": "MIT",
   "type": "module",
   "main": "./src/server.ts",

--- a/packages/posecode-lsp/src/server.ts
+++ b/packages/posecode-lsp/src/server.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Posecode language server (stdio). Thin wiring around the pure converters in
- * convert.ts — diagnostics on change, completion, and hover. Run via `tsx` in
+ * convert.ts: diagnostics on change, completion, and hover. Run via `tsx` in
  * dev or as the bundled `dist/server.cjs` from the VS Code extension.
  */
 

--- a/packages/posecode-mcp/README.md
+++ b/packages/posecode-mcp/README.md
@@ -5,7 +5,7 @@ It gives any MCP-capable agent (Claude Desktop, Cursor, …) a native way to *sh
 movement*: learn the `.posecode` language, validate a movement against healthy
 range-of-motion limits, and get a link that animates it as a 3D figure.
 
-This closes the loop the playground left open — no copy-pasting a system prompt
+This closes the loop the playground left open: no copy-pasting a system prompt
 or shuttling text between a chat window and the editor.
 
 ## Tools
@@ -42,12 +42,12 @@ npm start -w posecode-mcp          # tsx src/stdio.ts
 }
 ```
 
-`POSECODE_BASE_URL` is optional — it sets the playground that render permalinks
+`POSECODE_BASE_URL` is optional: it sets the playground that render permalinks
 point at (defaults to the hosted playground).
 
 ## How it fits
 
-`render_posecode` builds its links with [`posecode-share`](../posecode-share) — the same
-permalink primitive the playground uses — and validates with
+`render_posecode` builds its links with [`posecode-share`](../posecode-share), the same
+permalink primitive the playground uses, and validates with
 [`posecode-parser`](../posecode-parser). The server holds no rendering itself; 3D math
 runs client-side when the link is opened.

--- a/packages/posecode-mcp/src/analyze.ts
+++ b/packages/posecode-mcp/src/analyze.ts
@@ -3,8 +3,8 @@
  *
  * Turns a `.posecode` document into the structured results the MCP tools
  * return: a validation summary (errors + ROM-safety clamps) and a render
- * result that adds a playground permalink. No MCP or I/O here — just parse →
- * shape — so it is trivially unit-testable.
+ * result that adds a playground permalink. No MCP or I/O here: just parse →
+ * shape, so it is trivially unit-testable.
  */
 
 import { parse, type Warning } from "posecode-parser";

--- a/packages/posecode-mcp/src/guide.ts
+++ b/packages/posecode-mcp/src/guide.ts
@@ -28,7 +28,7 @@ export function authoringGuide(): string {
 
 const FALLBACK_GUIDE = `# Authoring Posecode
 
-Output ONLY a \`.posecode\` document in a code block — no prose.
+Output ONLY a \`.posecode\` document in a code block, no prose.
 
 ## Grammar
 \`\`\`
@@ -45,6 +45,6 @@ posecode <kind> "<Name>"          # kind = exercise | stretch | posture
 Joints: neck head spine chest pelvis, and (singular or plural) shoulders elbows
 wrists hips knees ankles. Actions (degrees are absolute targets): flex/extend,
 abduct/adduct, rotate-in/rotate-out, dorsiflex/plantarflex, hold neutral, and
-hinge (hips only — closed-chain hip flexion: torso tips over planted feet with
+hinge (hips only, closed-chain hip flexion: torso tips over planted feet with
 a neutral spine; use for deadlift / forward fold instead of hips: flex).
 Stay within healthy range of motion; the renderer hard-clamps anything beyond.`;

--- a/packages/posecode-mcp/src/index.ts
+++ b/packages/posecode-mcp/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-mcp — public API.
+ * posecode-mcp: public API.
  *
  * A Model Context Protocol server that lets LLM agents author, validate, and
  * render Posecode movements natively. See `stdio.ts` for the runnable entry

--- a/packages/posecode-mcp/src/server.ts
+++ b/packages/posecode-mcp/src/server.ts
@@ -1,10 +1,10 @@
 /**
- * Posecode MCP server — exposes the Posecode protocol to any LLM agent.
+ * Posecode MCP server: exposes the Posecode protocol to any LLM agent.
  *
  * Three tools turn "an LLM knows biomechanics" into "an LLM can show movement":
- *   - posecode_authoring_guide — learn the .posecode language inline
- *   - validate_posecode        — parse + surface range-of-motion safety clamps
- *   - render_posecode          — get a playground link that animates the movement
+ *   - posecode_authoring_guide: learn the .posecode language inline
+ *   - validate_posecode:       parse + surface range-of-motion safety clamps
+ *   - render_posecode:         get a playground link that animates the movement
  *
  * The server is decoupled from any transport so it can be driven over stdio in
  * production and over an in-memory pair in tests.
@@ -38,7 +38,7 @@ export function createPosecodeServer(opts: PosecodeServerOptions = {}): McpServe
     {
       title: "How to write Posecode",
       description:
-        "Return the guide that teaches the Posecode (.posecode) language — grammar, joints, actions, and an example. Read this before writing a movement.",
+        "Return the guide that teaches the Posecode (.posecode) language: grammar, joints, actions, and an example. Read this before writing a movement.",
       inputSchema: {},
     },
     async () => ({ content: [{ type: "text" as const, text: authoringGuide() }] }),

--- a/packages/posecode-mcp/test/posecode-mcp.test.ts
+++ b/packages/posecode-mcp/test/posecode-mcp.test.ts
@@ -9,7 +9,7 @@ const VALID = [
   "  rig humanoid",
   "  pose start = standing",
   '  step "Deep" 1s linear:',
-  "    knees: flex 200", // over the 144° ROM ceiling — must clamp + warn
+  "    knees: flex 200", // over the 144° ROM ceiling: must clamp + warn
   '    cue "too deep"',
   "  repeat 2",
 ].join("\n");

--- a/packages/posecode-parser/README.md
+++ b/packages/posecode-parser/README.md
@@ -36,7 +36,7 @@ if (errors.length === 0 && ir) {
 }
 ```
 
-`parse()` never throws — malformed or out-of-range documents come back as
+`parse()` never throws: malformed or out-of-range documents come back as
 structured `errors`/`warnings` instead. Every joint angle in `ir` is hard-clamped
 to a healthy range of motion, so a hallucinated `knee: flex 200` renders at its
 safe ceiling with a warning, never an anatomically impossible joint.

--- a/packages/posecode-parser/src/clamp.ts
+++ b/packages/posecode-parser/src/clamp.ts
@@ -4,7 +4,7 @@
  * This is the biomechanics-aware stage: it expands symmetric joint groups,
  * maps semantic actions to rotation axes (with left/right mirroring), and
  * clamps every angle into its safe Range of Motion (§5.1). All inputs are
- * treated as immutable — a fresh IR is built and returned.
+ * treated as immutable: a fresh IR is built and returned.
  */
 
 import type {
@@ -124,7 +124,7 @@ function resolveStep(
   }));
 
   // Reach / pin effectors: expand symmetric groups (`hands` → both hands) and
-  // reject unknown names — a typo'd effector would otherwise be silently
+  // reject unknown names, since a typo'd effector would otherwise be silently
   // ignored by the renderer, invisible to the authoring LLM.
   const reaches: ReachTarget[] = [];
   for (const r of step.reaches) {

--- a/packages/posecode-parser/src/index.ts
+++ b/packages/posecode-parser/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-parser — public API.
+ * posecode-parser: public API.
  *
  * `parse()` turns `.posecode` source into a validated, ROM-clamped `PosecodeIR`.
  * Pipeline: tokenize → parse to AST → zod boundary validation → resolve+clamp.

--- a/packages/posecode-parser/src/joints.ts
+++ b/packages/posecode-parser/src/joints.ts
@@ -1,7 +1,7 @@
 /**
  * Joint vocabulary and the semantic-action → rotation-axis mapping.
  *
- * Coordinate convention (must match the renderer's rig — see spec/SPEC.md):
+ * Coordinate convention (must match the renderer's rig: see spec/SPEC.md):
  *   Rest pose: standing, arms at sides, facing +Z. Each bone rotates in its
  *   own local frame where
  *     X = sagittal plane  (flexion / extension)
@@ -9,7 +9,7 @@
  *     Z = frontal plane   (abduction / adduction)
  *   The unmirrored sign of each action is the RIGHT side's (the body's right
  *   is -X); left-side bones mirror the Y and Z axes so symmetric cues look
- *   symmetric — `shoulders: abduct 80` lifts both arms away from the midline.
+ *   symmetric: `shoulders: abduct 80` lifts both arms away from the midline.
  */
 
 import type { Axis } from "./types.js";
@@ -155,7 +155,7 @@ const ACTIONS: Record<string, ActionAxis> = {
   // Hip hinge: tip the torso forward over the hip line (deadlift, row, bow,
   // good-morning). Applied to the `pelvis`, whose torso child points UP, so
   // forward is +X (like spine flexion). The renderer counter-rotates the hips
-  // so the legs stay planted — see posecode-render/src/timeline.ts.
+  // so the legs stay planted; see posecode-render/src/timeline.ts.
   hinge: { axis: "x", sign: 1 },
 };
 
@@ -172,7 +172,7 @@ export function actionAxis(action: string): ActionAxis | null {
  * (their child chain points DOWN), so flexing toward +Z (anatomically
  * forward: hip, shoulder, elbow, wrist, fingers) is a -X rotation. The AXIAL
  * chain (spine, chest, neck, head) points UP, so the same forward bend is +X.
- * The KNEE is the odd limb out — it flexes backward (heel toward the buttock),
+ * The KNEE is the odd limb out: it flexes backward (heel toward the buttock),
  * +X. `extend` is the opposite of `flex`. Used by the resolver to sign
  * flex/extend per joint so a squat folds and a crunch curls forward instead
  * of inverting.

--- a/packages/posecode-parser/src/parser.ts
+++ b/packages/posecode-parser/src/parser.ts
@@ -1,7 +1,7 @@
 /**
  * Recursive-descent parser: tokenized lines → an Abstract Syntax Tree.
  *
- * The AST is intentionally "shallow" — it captures what was written without
+ * The AST is intentionally "shallow": it captures what was written without
  * resolving joints, axes, or ROM. That resolution happens in `clamp.ts`,
  * keeping parsing and biomechanics cleanly separated.
  */
@@ -118,7 +118,7 @@ export function parseToAst(source: string): ParseAstResult {
         break;
       }
       case "prop": {
-        // `prop <type>` — a scene object (chair | wall | bar), repeatable.
+        // `prop <type>`: a scene object (chair | wall | bar), repeatable.
         const p = word(t[1]);
         if (!p) errors.push({ line: ln.line, message: "prop requires a type" });
         else doc.props.push(p);
@@ -207,7 +207,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
   }
 
   if (head === "reach") {
-    // `reach: <effector> <target>` — drive an effector to a world target via IK.
+    // `reach: <effector> <target>`: drive an effector to a world target via IK.
     if (!current) return { line: ln.line, message: "`reach` outside of a step" };
     const effector = t[2]?.type === "word" ? t[2].value : null;
     const target = t[3]?.type === "word" ? t[3].value : null;
@@ -219,7 +219,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
   }
 
   if (head === "pin") {
-    // `pin: <effector> <anchor>` — translate the body so the effector sits there.
+    // `pin: <effector> <anchor>`: translate the body so the effector sits there.
     if (!current) return { line: ln.line, message: "`pin` outside of a step" };
     const effector = t[2]?.type === "word" ? t[2].value : null;
     const anchor = t[3]?.type === "word" ? t[3].value : null;
@@ -231,7 +231,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
   }
 
   if (head === "turn") {
-    // `turn: <degrees>` — the figure's facing (root yaw about world Y) at the
+    // `turn: <degrees>`: the figure's facing (root yaw about world Y) at the
     // end of this phase. Absolute, accumulated forward like a joint target.
     if (!current) return { line: ln.line, message: "`turn` outside of a step" };
     if (t[1]?.type !== "colon" || t[2]?.type !== "num") {
@@ -242,7 +242,7 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
   }
 
   if (head === "travel") {
-    // `travel: <x> <z>` — the figure's ground position (world X/Z metres) at the
+    // `travel: <x> <z>`: the figure's ground position (world X/Z metres) at the
     // end of this phase. Absolute offset from the load spot, accumulated forward.
     if (!current) return { line: ln.line, message: "`travel` outside of a step" };
     if (t[1]?.type !== "colon" || t[2]?.type !== "num" || t[3]?.type !== "num") {

--- a/packages/posecode-parser/src/rom.ts
+++ b/packages/posecode-parser/src/rom.ts
@@ -3,8 +3,8 @@
  *
  * Values follow the maximum healthy limits in the project research
  * (CDC / clinical normative data), §5.1 Tables 1 & 2. The clamp pass treats
- * `max` as a HARD ceiling — e.g. a requested knee flexion of 200° is clamped to
- * 144° — so the renderer can never produce an anatomically impossible joint.
+ * `max` as a HARD ceiling: e.g. a requested knee flexion of 200° is clamped to
+ * 144°, so the renderer can never produce an anatomically impossible joint.
  *
  * `min` is the floor of the achievable angle for that action direction (0 for
  * most; small positive ceilings on extension capture hyperextension limits).
@@ -113,7 +113,7 @@ export type EulerRom = Record<Axis, RomLimit>;
 
 /**
  * The full ROM of a bone expressed as a signed Euler box in the renderer's
- * local frame — the same frame `clamp.ts` resolves authored actions into
+ * local frame: the same frame `clamp.ts` resolves authored actions into
  * (flexion-sign per joint, Y/Z mirrored on left-side bones). Each axis range is
  * the union of every action that rotates it; axes with no ROM entry stay
  * `{min: 0, max: 0}`, locking them (a knee is a pure hinge). This is what lets

--- a/packages/posecode-parser/src/schema.ts
+++ b/packages/posecode-parser/src/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Zod schema for the AST — a defensive boundary check before resolution.
+ * Zod schema for the AST: a defensive boundary check before resolution.
  *
  * The parser already produces a typed AST, but validating it here catches
  * malformed easings and structural surprises in one place (coding-style:

--- a/packages/posecode-parser/src/types.ts
+++ b/packages/posecode-parser/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the Posecode protocol.
  *
- * The parser turns `.posecode` source into a `PosecodeIR` — a renderer-agnostic
+ * The parser turns `.posecode` source into a `PosecodeIR`: a renderer-agnostic
  * intermediate representation. Angles in the IR are in DEGREES (human-readable);
  * the renderer converts to radians. Joint rotations follow the coordinate
  * convention documented in `joints.ts` and `spec/SPEC.md`.
@@ -60,13 +60,13 @@ export interface Phase {
   /** Contact pins active during this phase (translate the body to the anchor). */
   pins: PinTarget[];
   /**
-   * Root facing (yaw about world Y, degrees) at the end of this phase — an
+   * Root facing (yaw about world Y, degrees) at the end of this phase, an
    * absolute target carried forward across phases. Powers turns / pirouettes.
    */
   turnDeg?: number;
   /**
    * Root ground position (world X/Z metres, offset from the load spot) at the
-   * end of this phase — absolute, carried forward. Powers travel / locomotion.
+   * end of this phase, absolute, carried forward. Powers travel / locomotion.
    */
   travel?: { x: number; z: number };
   cue?: string;

--- a/packages/posecode-parser/test/examples.test.ts
+++ b/packages/posecode-parser/test/examples.test.ts
@@ -46,7 +46,7 @@ describe("hip-hinge action", () => {
     expect(errors).toEqual([]);
     expect(warnings).toEqual([]);
     const pelvis = ir!.phases[0]!.targets.find((t) => t.boneId === "pelvis")!;
-    // hinge tips the torso forward — same sagittal direction as spine flex (+X,
+    // hinge tips the torso forward: same sagittal direction as spine flex (+X,
     // the axial chain points up).
     expect(pelvis.euler.x).toBe(80);
   });

--- a/packages/posecode-render/src/groundlock.ts
+++ b/packages/posecode-render/src/groundlock.ts
@@ -9,14 +9,14 @@
  * - **Hands + feet (push-up / plank):** pivot the whole rigid body about the
  *   foot line (the toes stay planted) until the hands reach the floor. As the
  *   elbows fold (FK), the hands rise toward the shoulders, so the body tips
- *   down around the toes — the torso lowers in one straight line, a real
+ *   down around the toes: the torso lowers in one straight line, a real
  *   push-up. Rotating about an X-axis through the foot midpoint keeps both
  *   feet exactly planted (they differ from the pivot only along X).
  * - **Feet only (squat / hinge / roll-down):** drop the body vertically so the
- *   feet stay planted while the legs keep their authored FK bend — the pelvis
+ *   feet stay planted while the legs keep their authored FK bend: the pelvis
  *   lowers. Legs are never CCD-solved (that would overwrite the pose).
  *
- * Both paths ground the visible MESH (bounding boxes), not just bone origins —
+ * Both paths ground the visible MESH (bounding boxes), not just bone origins:
  * an ankle bone sits ~0.04m above the sole, so anchoring bones alone left the
  * feet sunk into the floor.
  */
@@ -29,7 +29,7 @@ const ROOT_X = new THREE.Vector3(1, 0, 0);
 /**
  * Drop the whole figure so its lowest point rests on the floor. Using the
  * mesh bounding-box min (not just hand/foot joints) means ANY pose grounds
- * correctly — standing/plank rest on feet/hands, while supine/prone/seated
+ * correctly: standing/plank rest on feet/hands, while supine/prone/seated
  * poses rest on the back, chest, or glutes.
  */
 export function groundFigure(m: Mannequin): void {
@@ -106,7 +106,7 @@ export function applyGroundLock(m: Mannequin, active: string[]): void {
   }
 
   if (feet.length > 0) {
-    // Ground the FOOT MESH's lowest point, not the ankle bone's origin — the
+    // Ground the FOOT MESH's lowest point, not the ankle bone's origin: the
     // bone sits ~0.04m above the sole (foot box + capsule radius), so
     // anchoring the bone itself left the visible foot sunk into the floor.
     let minY = Infinity;

--- a/packages/posecode-render/src/ik.ts
+++ b/packages/posecode-render/src/ik.ts
@@ -1,6 +1,6 @@
 /**
  * Generic Cyclic Coordinate Descent (CCD) inverse kinematics over an Object3D
- * bone chain — the §6.2 algorithm, adapted to our rigid-segment rig (Three's
+ * bone chain: the §6.2 algorithm, adapted to our rigid-segment rig (Three's
  * built-in CCDIKSolver is bound to SkinnedMesh, which we don't use).
  *
  * Used for ground-lock and reach: pinning or driving a hand/foot effector to a
@@ -15,7 +15,7 @@ import * as THREE from "three";
 
 /**
  * Per-axis rotation limits (radians) in a joint's LOCAL Euler (XYZ) frame.
- * Axes the joint cannot rotate use `[0, 0]` — e.g. a knee is a pure hinge.
+ * Axes the joint cannot rotate use `[0, 0]`, e.g. a knee is a pure hinge.
  */
 export interface JointLimits {
   x: [number, number];

--- a/packages/posecode-render/src/index.ts
+++ b/packages/posecode-render/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-render — public API.
+ * posecode-render: public API.
  *
  * `createViewer(canvas)` sets up a Three.js studio scene with the procedural
  * mannequin and returns a controller. `load(ir)` builds a timeline from a parsed
@@ -181,7 +181,7 @@ export function createViewer(
 
   function captureGroundTargets(): void {
     // "Ground-lock" means HOLD the effector where the grounded base pose placed
-    // it — not drag it to y=0. groundFigure() already set the floor contact.
+    // it, not drag it to y=0. groundFigure() already set the floor contact.
     groundTargets = new Map();
     for (const ids of Object.values(mannequin.effectors)) {
       for (const id of ids) {
@@ -210,7 +210,7 @@ export function createViewer(
    * A limit box is widened to include the joint's CURRENT (authored FK) angle:
    * the timeline pose is already ROM-clamped in author terms, but rig mechanics
    * such as the hip-hinge counter-rotation can place a bone outside its raw box
-   * on purpose — IK must never fight the authored pose, only be prevented from
+   * on purpose: IK must never fight the authored pose, only be prevented from
    * pushing beyond it.
    */
   function reachChain(effectorBone: string): {
@@ -271,7 +271,7 @@ export function createViewer(
 
   /**
    * Reach-IK: drive each active effector to its world target with ROM-
-   * constrained CCD — the solved arm/leg obeys the same hard joint limits as
+   * constrained CCD: the solved arm/leg obeys the same hard joint limits as
    * authored angles, so an unreachable target yields the closest SAFE pose.
    * Runs AFTER ground-lock so landmark/floor targets are resolved against the
    * final root placement. The chain is the arm (hand) or the leg (foot); other
@@ -293,7 +293,7 @@ export function createViewer(
   /**
    * Contact pins: translate the WHOLE figure so each pinned effector sits on its
    * anchor. Where ground-lock keeps a planted foot on the floor, a pin keeps a
-   * hand on the bar or a foot on the box while the body moves relative to it —
+   * hand on the bar or a foot on the box while the body moves relative to it,
    * so the figure hangs from a bar, pulls up toward it, rises onto a box, or
    * lowers into a dip as the limb joints work. Applied after ground-lock (which
    * pinned movements normally omit) and before reach-IK.
@@ -319,7 +319,7 @@ export function createViewer(
 
   function frameCamera(): void {
     // Auto-frame the figure: fit its bounding box, keep a pleasant angle.
-    // Include any scene prop too — a pull-up bar sits well above the figure's
+    // Include any scene prop too: a pull-up bar sits well above the figure's
     // head, and framing on the mannequin alone left it cropped out of view.
     const box = new THREE.Box3().setFromObject(mannequin.root);
     if (propScene) box.union(new THREE.Box3().setFromObject(propScene.group));
@@ -366,7 +366,7 @@ export function createViewer(
       applyPins(info.pins);
       // Safety net: nothing above ever intentionally pushes part of the body
       // below the floor, so clamp the root up whenever the lowest point dips
-      // below y=0 — a no-op whenever the pose is legitimately grounded or
+      // below y=0, a no-op whenever the pose is legitimately grounded or
       // elevated (bbox min already ≥ 0). This also catches phases with
       // neither ground-lock nor a pin (the root stays frozen at the base
       // pose's grounded height while FK animates freely on top of it, e.g. a
@@ -435,7 +435,7 @@ export function createViewer(
         enableShadows(propScene.group);
         scene.add(propScene.group);
       }
-      // Reset every bone to rest — otherwise joints from a previous movement
+      // Reset every bone to rest: otherwise joints from a previous movement
       // that this document doesn't touch would persist (e.g. bent legs from a
       // squat showing under a biceps curl).
       for (const bone of mannequin.bones.values()) bone.quaternion.identity();

--- a/packages/posecode-render/src/mannequin.ts
+++ b/packages/posecode-render/src/mannequin.ts
@@ -2,7 +2,7 @@
  * Procedural low-poly mannequin.
  *
  * Built from rigid capsule/sphere segments parented to an Object3D bone
- * hierarchy — the "wooden artist mannequin" look. No external assets, no
+ * hierarchy: the "wooden artist mannequin" look. No external assets, no
  * skinning: each bone is a joint node, and limb meshes hang off the proximal
  * bone so they follow its local rotation (forward kinematics).
  *
@@ -52,10 +52,10 @@ const SKELETON: BoneSpec[] = [
   { id: "knee_right", parent: "hip_right", offset: [0, -0.45, 0], radius: 0.05 },
   { id: "ankle_right", parent: "knee_right", offset: [0, -0.43, 0], radius: 0.04 },
 
-  // Fingers — one curl DOF each (flex), splayed in X and angled slightly
+  // Fingers: one curl DOF each (flex), splayed in X and angled slightly
   // forward (+Z, palm-side). Offsets are the FINGERTIP position; the bone is
   // placed partway along at the knuckle (KNUCKLE_T) so the wrist-drawn segment
-  // becomes the rigid palm/metacarpal and the bone carries its own digit mesh —
+  // becomes the rigid palm/metacarpal and the bone carries its own digit mesh,
   // otherwise curling a finger rotates an empty node and the hand never moves.
   { id: "thumb_left", parent: "wrist_left", offset: [0.035, -0.04, 0.025], radius: 0.014 },
   { id: "index_left", parent: "wrist_left", offset: [0.025, -0.085, 0.012], radius: 0.013 },
@@ -164,7 +164,7 @@ function addBall(bone: THREE.Object3D, diameter: number, mat: THREE.Material): v
 }
 
 /**
- * A minimal face — nose wedge + two eye studs — on the head's front (+Z).
+ * A minimal face (nose wedge + two eye studs) on the head's front (+Z).
  * The bare sphere hid which way the figure faces, making neck rotations and
  * turns unreadable; darker studs poke just past the head surface so facing
  * reads at a glance from any camera angle.

--- a/packages/posecode-render/src/props.ts
+++ b/packages/posecode-render/src/props.ts
@@ -1,10 +1,10 @@
 /**
- * Scene props — objects the figure sits on, leans against, or grips.
+ * Scene props: objects the figure sits on, leans against, or grips.
  *
  * A prop is a simple low-poly mesh at a fixed default transform plus named
  * **anchors**: world-space contact points the movement can reference from a
  * `reach:` line (e.g. `reach: hand_left bar`). Props are NOT parented to the
- * mannequin — they live in the world and the figure moves to meet them.
+ * mannequin: they live in the world and the figure moves to meet them.
  *
  * Default placement is chosen so each prop sits where its movements need it and
  * distinct props don't collide: the chair is just behind the figure, the wall
@@ -88,7 +88,7 @@ export function buildProps(types: string[], material?: THREE.Material): PropScen
       }
       anchors.set("bars", new THREE.Vector3(0, railH, 0));
     } else if (type === "box") {
-      // A low step/plateau placed IN FRONT of the figure (+Z) — the lead foot
+      // A low step/plateau placed IN FRONT of the figure (+Z): the lead foot
       // steps forward and up onto it. Top surface at ~0.30 m; `box` anchor sits
       // on top where the foot lands.
       const topH = 0.3;

--- a/packages/posecode-render/src/timeline.ts
+++ b/packages/posecode-render/src/timeline.ts
@@ -61,7 +61,7 @@ export interface BuiltTimeline {
     /** Interpolated root ground offset (world X/Z metres) from the load spot. */
     rootOffset: { x: number; z: number };
   };
-  /** Largest travel offset magnitude reached (metres) — for camera framing. */
+  /** Largest travel offset magnitude reached (metres), for camera framing. */
   travelExtent: number;
 }
 
@@ -223,7 +223,7 @@ function snapshot(curr: Map<string, EulerDegTuple>): Map<string, THREE.Quaternio
   for (const [bone, euler] of curr) out.set(bone, eulerToQuat(euler));
 
   // Hip-hinge coupling. The `pelvis` is the shared parent of both the torso and
-  // the legs, so a pelvis X-rotation tips the WHOLE figure forward — torso and
+  // the legs, so a pelvis X-rotation tips the WHOLE figure forward: torso and
   // legs alike. A real hip hinge keeps the legs planted and pivots only the
   // torso over the hip line, so counter-rotate the hips by the same X angle:
   // the thighs (hence shins and feet) stay world-vertical while the torso tips.

--- a/packages/posecode-render/test/render.test.ts
+++ b/packages/posecode-render/test/render.test.ts
@@ -205,7 +205,7 @@ describe("reach-IK", () => {
     const wrist = m.bones.get("wrist_right")!;
     const shoulder = m.bones.get("shoulder_right")!;
 
-    // A target ~0.47m from the shoulder — inside the ~0.54m arm reach — so the
+    // A target ~0.47m from the shoulder (inside the ~0.54m arm reach) so the
     // hand can actually arrive (a body landmark like a knee is out of range from
     // a neutral stand, which is exactly why touch-toes hinges the torso first).
     const target = shoulder
@@ -272,7 +272,7 @@ describe("ground-lock (shared solver)", () => {
     );
     applyGroundLock(m, ["feet"]);
     m.root.updateMatrixWorld(true);
-    // Pelvis well below standing rest (~0.95m) — the body lowered into a squat.
+    // Pelvis well below standing rest (~0.95m): the body lowered into a squat.
     const pelvisY = m.bones.get("pelvis")!.getWorldPosition(new THREE.Vector3()).y;
     expect(pelvisY).toBeLessThan(0.85);
     // Foot MESH sole rests on the floor (ankle bone rides ~0.04m above it).
@@ -546,7 +546,7 @@ describe("frontal plane direction", () => {
     m.root.updateMatrixWorld(true);
 
     // Each distal joint must sit FURTHER from the midline (|x|) than its
-    // proximal joint, on the SAME side — the inverted sign swung all four
+    // proximal joint, on the SAME side: the inverted sign swung all four
     // limbs across the body instead.
     for (const [distal, proximal] of [
       ["wrist_left", "shoulder_left"],

--- a/packages/posecode-share/src/index.ts
+++ b/packages/posecode-share/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * posecode-share — the distribution primitive for Posecode.
+ * posecode-share: the distribution primitive for Posecode.
  *
  * Encodes a `.posecode` document into a compact, URL-safe token so any movement
  * can travel as a link and render wherever it lands. This is the mechanic that
@@ -50,7 +50,7 @@ export function buildShareHash(source: string): string {
 /**
  * Extract a shared document from a `location.hash`. This is the untrusted
  * boundary: a hand-edited or truncated link must degrade to "no shared doc"
- * rather than crash the page, so this never throws — it returns null instead.
+ * rather than crash the page, so this never throws: it returns null instead.
  */
 export function readShareHash(hash: string): string | null {
   if (typeof hash !== "string") return null;

--- a/packages/posecode-share/test/share.test.ts
+++ b/packages/posecode-share/test/share.test.ts
@@ -59,7 +59,7 @@ describe("posecode-share codec", () => {
 
   it("rejects empty or non-string input when encoding", () => {
     expect(() => encodePosecode("")).toThrow();
-    // @ts-expect-error — guarding the runtime boundary against bad callers
+    // @ts-expect-error: guarding the runtime boundary against bad callers
     expect(() => encodePosecode(null)).toThrow();
   });
 

--- a/playground/public/llm-guide.html
+++ b/playground/public/llm-guide.html
@@ -118,7 +118,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <h1>Authoring <code>.posecode</code> with an LLM</h1>
 <p>Paste the prompt below into ChatGPT, Claude, or any capable model. Then ask for a movement (&quot;write a squat&quot;, &quot;show a hamstring stretch&quot;) and paste the reply into the Posecode playground.</p>
 <hr>
-<p>You write <strong>Posecode</strong>, a small text language that describes a single person's movement so a 3D mannequin can animate it. Output ONLY a <code>.posecode</code> document in a code block — no prose.</p>
+<p>You write <strong>Posecode</strong>, a small text language that describes a single person's movement so a 3D mannequin can animate it. Output ONLY a <code>.posecode</code> document in a code block, no prose.</p>
 <h2>Grammar</h2>
 <pre class="code-block"><code>posecode &lt;kind&gt; &quot;&lt;Name&gt;&quot;          # kind = exercise | stretch | posture
   rig humanoid
@@ -135,9 +135,9 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <h2>Joints</h2>
 <p><code>neck head spine chest pelvis</code> and (singular or plural) <code>shoulders elbows wrists hips knees ankles</code>. Plural names move both sides symmetrically; use <code>elbow_left</code> etc. for one side. Fingers: <code>fingers</code> (or <code>fingers_left</code> / <code>fingers_right</code>), and individually <code>thumb_* index_* middle_* ring_* pinky_*</code>.</p>
 <h2>Actions (degrees are absolute targets)</h2>
-<ul><li><code>flex</code> / <code>extend</code> — bend / straighten (sagittal)</li><li><code>abduct</code> / <code>adduct</code> — away from / toward midline (frontal)</li><li><code>rotate-in</code> / <code>rotate-out</code> — internal / external rotation</li><li><code>supinate</code> / <code>pronate</code> — forearm turn (palm up / down)</li><li><code>dorsiflex</code> / <code>plantarflex</code> — ankle up / down</li><li><code>hinge</code> — <strong>hip hinge</strong> (on <code>pelvis</code> only): tip the torso forward over the</li></ul>
-<p>hips with a flat back, legs staying planted. Use this — not spinal <code>flex</code> — for a deadlift, bent-over row, good-morning, or a bow.</p>
-<ul><li><code>hold neutral</code> — keep the joint at rest</li></ul>
+<ul><li><code>flex</code> / <code>extend</code>: bend / straighten (sagittal)</li><li><code>abduct</code> / <code>adduct</code>: away from / toward midline (frontal)</li><li><code>rotate-in</code> / <code>rotate-out</code>: internal / external rotation</li><li><code>supinate</code> / <code>pronate</code>: forearm turn (palm up / down)</li><li><code>dorsiflex</code> / <code>plantarflex</code>: ankle up / down</li><li><code>hinge</code>: <strong>hip hinge</strong> (on <code>pelvis</code> only): tip the torso forward over the</li></ul>
+<p>hips with a flat back, legs staying planted. Use this, not spinal <code>flex</code>, for a deadlift, bent-over row, good-morning, or a bow.</p>
+<ul><li><code>hold neutral</code>: keep the joint at rest</li></ul>
 <h2>Rules</h2>
 <ol><li>Break the movement into 2–5 concurrent <strong>phases</strong>; each <code>step</code> is one phase.</li><li>Set the joints that actually move in that phase; unset joints hold their</li></ol>
 <p>previous value.</p>
@@ -177,7 +177,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     knees: flex 25
     shoulders: flex 90
     ground-lock: feet
-    cue &quot;Hips back, flat back — let the arms hang to the bar&quot;
+    cue &quot;Hips back, flat back: let the arms hang to the bar&quot;
 
   step &quot;Lift&quot; 1.4s ease-out:
     pelvis: hinge 0
@@ -188,26 +188,26 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 
   repeat 8</code></pre>
 <h2>Reaching, props, lying poses &amp; hands</h2>
-<ul><li><strong>Reach a target</strong> — <code>reach: &lt;effector&gt; &lt;target&gt;</code> drives a hand or foot to a</li></ul>
-<p>world point via IK. Effectors: <code>hand_left hand_right foot_left foot_right</code>, or <code>hands</code> / <code>feet</code> for both sides at once. Targets: a body landmark bone (<code>ankle_left</code>, <code>knee_right</code>…), <code>floor</code>, or a prop anchor (<code>bar</code>, <code>seat</code>, <code>wall</code>). The solve is ROM-constrained — the arm/leg can never exceed the safe joint limits chasing a target, so an out-of-reach target just yields the closest healthy pose. Author the gross pose (e.g. a <code>pelvis: hinge</code>), then let <code>reach</code> finish the hand placement. Example — touch your toes:</p>
+<ul><li><strong>Reach a target</strong>: <code>reach: &lt;effector&gt; &lt;target&gt;</code> drives a hand or foot to a</li></ul>
+<p>world point via IK. Effectors: <code>hand_left hand_right foot_left foot_right</code>, or <code>hands</code> / <code>feet</code> for both sides at once. Targets: a body landmark bone (<code>ankle_left</code>, <code>knee_right</code>…), <code>floor</code>, or a prop anchor (<code>bar</code>, <code>seat</code>, <code>wall</code>). The solve is ROM-constrained: the arm/leg can never exceed the safe joint limits chasing a target, so an out-of-reach target just yields the closest healthy pose. Author the gross pose (e.g. a <code>pelvis: hinge</code>), then let <code>reach</code> finish the hand placement. Example, touch your toes:</p>
 <p>``<code>posecode step &quot;Fold&quot; 2.5s ease-in-out: pelvis: hinge 95 knees: flex 12 reach: hand_left ankle_left reach: hand_right ankle_right ground-lock: feet cue &quot;Hinge and reach toward the ankles&quot; </code>``</p>
-<ul><li><strong>Props</strong> — <code>prop chair | wall | bar | box | dip-bars</code> (top level). The chair</li></ul>
+<ul><li><strong>Props</strong>: <code>prop chair | wall | bar | box | dip-bars</code> (top level). The chair</li></ul>
 <p>sits behind the figure (sit-to-stand, box squat), the wall behind that (wall sit), the bar overhead, the box in front (step-ups), and the dip bars either side at hip-press height (<code>pin: hands bars</code> + elbow flex = triceps dips).</p>
-<ul><li><strong>Pins</strong> — <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> moves the whole BODY so the effector sits</li></ul>
+<ul><li><strong>Pins</strong>: <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> moves the whole BODY so the effector sits</li></ul>
 <p>on the anchor (vs <code>reach</code>, which moves just the limb). Same effectors as reach, including <code>hands</code> / <code>feet</code>. Use it for hanging and climbing: <code>pin: hands bar</code> + flexing the elbows = a pull-up; <code>pin: foot_right box</code> + straightening the leg = a step-up; <code>pin: hands bars</code> (dip bars) + bending the elbows = a triceps dip.</p>
-<ul><li><strong>Lying / seated</strong> — <code>pose start = supine | prone | seated</code> for floor and mat</li></ul>
+<ul><li><strong>Lying / seated</strong>: <code>pose start = supine | prone | seated</code> for floor and mat</li></ul>
 <p>work (glute bridge, dead bug, cobra, seated forward fold).</p>
-<ul><li><strong>Hands</strong> — <code>fingers: flex 80</code> makes a fist; curl individual fingers for shapes</li></ul>
-<p>(<code>index_right: flex 95</code>). Single-DOF per finger — good for grip and rough gesture, not exact sign language.</p>
+<ul><li><strong>Hands</strong>: <code>fingers: flex 80</code> makes a fist; curl individual fingers for shapes</li></ul>
+<p>(<code>index_right: flex 95</code>). Single-DOF per finger, good for grip and rough gesture, not exact sign language.</p>
 <h2>Authoring by domain</h2>
 <p>The same grammar covers many fields. A few patterns that read well:</p>
-<ul><li><strong>Anatomy / education</strong> — isolate one joint and sweep it through its range</li></ul>
+<ul><li><strong>Anatomy / education</strong>: isolate one joint and sweep it through its range</li></ul>
 <p>(<code>shoulders: abduct 160</code> → <code>0</code>). Name the plane in the cue. Great for teaching.</p>
-<ul><li><strong>Physiotherapy</strong> — gentle, single-joint reps; for one-sided work use a</li></ul>
+<ul><li><strong>Physiotherapy</strong>: gentle, single-joint reps; for one-sided work use a</li></ul>
 <p>singular joint (<code>knee_right: flex 95</code>) and skip <code>ground-lock</code> so the standing leg stays planted.</p>
-<ul><li><strong>Desk / posture</strong> — slow <code>stretch</code> documents with <code>ground-lock: feet</code>;</li></ul>
+<ul><li><strong>Desk / posture</strong>: slow <code>stretch</code> documents with <code>ground-lock: feet</code>;</li></ul>
 <p>contrast a &quot;collapsed&quot; phase with a &quot;tall&quot; reset.</p>
-<ul><li><strong>Sports / martial arts</strong> — short, snappy phases (0.3–0.6s) with <code>ease-out</code></li></ul>
+<ul><li><strong>Sports / martial arts</strong>: short, snappy phases (0.3–0.6s) with <code>ease-out</code></li></ul>
 <p>on the strike; chamber → extend → re-chamber → return.</p>
 <h3>Dance / choreography</h3>
 <p>Posecode shines for <strong>showing the movement in your head</strong>. Build a phrase as a sequence of phases, one per count or musical beat, and let later phases inherit unset joints:</p>
@@ -217,13 +217,13 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <p>relevé to spin on the balls of the feet; <code>turn: 90</code> for a quarter-turn.</p>
 <ul><li><strong>Travel across the floor:</strong> <code>travel: &lt;x&gt; &lt;z&gt;</code> (metres from the start spot,</li></ul>
 <p>absolute). A box-step traces a square back home: <code>travel: 0.4 0</code> → <code>0.4 0.4</code> → <code>0 0.4</code> → <code>0 0</code>. A grapevine travels sideways; a walk cycle steps forward in +z. Add the stepping legs with FK on top.</p>
-<p>Both <code>turn</code> and <code>travel</code> are <strong>absolute and carried forward</strong> like joint angles, and both return home on the loop wrap, so phrases resolve cleanly. They work from <strong>standing</strong> poses only. Name each step by its count (<code>&quot;5-6 - relevé, arms en haut&quot;</code>) so the phrase reads like choreography. To extend a phrase, append more steps — the figure carries its pose forward. Use <code>ground-lock: feet</code> for grounded phrases (it still lets the figure turn and travel — it only keeps the feet on the floor vertically).</p>
+<p>Both <code>turn</code> and <code>travel</code> are <strong>absolute and carried forward</strong> like joint angles, and both return home on the loop wrap, so phrases resolve cleanly. They work from <strong>standing</strong> poses only. Name each step by its count (<code>&quot;5-6 - relevé, arms en haut&quot;</code>) so the phrase reads like choreography. To extend a phrase, append more steps; the figure carries its pose forward. Use <code>ground-lock: feet</code> for grounded phrases (it still lets the figure turn and travel; it only keeps the feet on the floor vertically).</p>
     </main>
     <footer class="site-footer">
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/arm-circles.html
+++ b/playground/public/moves/arm-circles.html
@@ -173,7 +173,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/bent-over-row.html
+++ b/playground/public/moves/bent-over-row.html
@@ -194,7 +194,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/biceps.html
+++ b/playground/public/moves/biceps.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/bicycle-crunch.html
+++ b/playground/public/moves/bicycle-crunch.html
@@ -197,7 +197,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/bow.html
+++ b/playground/public/moves/bow.html
@@ -170,7 +170,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/box-squat.html
+++ b/playground/public/moves/box-squat.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/box-step-taps.html
+++ b/playground/public/moves/box-step-taps.html
@@ -185,7 +185,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/box-step.html
+++ b/playground/public/moves/box-step.html
@@ -198,7 +198,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/calf-raise.html
+++ b/playground/public/moves/calf-raise.html
@@ -166,7 +166,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/chair.html
+++ b/playground/public/moves/chair.html
@@ -174,7 +174,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/chasse.html
+++ b/playground/public/moves/chasse.html
@@ -200,7 +200,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/chest-opener.html
+++ b/playground/public/moves/chest-opener.html
@@ -170,7 +170,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/cobra.html
+++ b/playground/public/moves/cobra.html
@@ -174,7 +174,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/cross-body-reach.html
+++ b/playground/public/moves/cross-body-reach.html
@@ -186,7 +186,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/crunch.html
+++ b/playground/public/moves/crunch.html
@@ -174,7 +174,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/dance-phrase.html
+++ b/playground/public/moves/dance-phrase.html
@@ -200,7 +200,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/dead-bug.html
+++ b/playground/public/moves/dead-bug.html
@@ -191,7 +191,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/dead-hang.html
+++ b/playground/public/moves/dead-hang.html
@@ -179,7 +179,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/deadlift.html
+++ b/playground/public/moves/deadlift.html
@@ -172,7 +172,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/demi-plie.html
+++ b/playground/public/moves/demi-plie.html
@@ -178,7 +178,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/elbow-forearm.html
+++ b/playground/public/moves/elbow-forearm.html
@@ -166,7 +166,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/finger-spell.html
+++ b/playground/public/moves/finger-spell.html
@@ -203,7 +203,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/fold.html
+++ b/playground/public/moves/fold.html
@@ -174,7 +174,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/forward-lunge.html
+++ b/playground/public/moves/forward-lunge.html
@@ -176,7 +176,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/front-kick.html
+++ b/playground/public/moves/front-kick.html
@@ -184,7 +184,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/glute-bridge.html
+++ b/playground/public/moves/glute-bridge.html
@@ -169,7 +169,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/good-morning.html
+++ b/playground/public/moves/good-morning.html
@@ -174,7 +174,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/grapevine.html
+++ b/playground/public/moves/grapevine.html
@@ -194,7 +194,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/hamstring-curl.html
+++ b/playground/public/moves/hamstring-curl.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/hand-wave.html
+++ b/playground/public/moves/hand-wave.html
@@ -183,7 +183,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/hanging-knee-raise.html
+++ b/playground/public/moves/hanging-knee-raise.html
@@ -206,7 +206,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/heel-raises.html
+++ b/playground/public/moves/heel-raises.html
@@ -166,7 +166,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/high-knee-march.html
+++ b/playground/public/moves/high-knee-march.html
@@ -181,7 +181,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/hip-abduction.html
+++ b/playground/public/moves/hip-abduction.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/hip-flexion.html
+++ b/playground/public/moves/hip-flexion.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/horse-stance.html
+++ b/playground/public/moves/horse-stance.html
@@ -178,7 +178,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/index.html
+++ b/playground/public/moves/index.html
@@ -493,7 +493,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/jab-cross.html
+++ b/playground/public/moves/jab-cross.html
@@ -188,7 +188,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/jumping-jacks.html
+++ b/playground/public/moves/jumping-jacks.html
@@ -168,7 +168,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/knee-flexion.html
+++ b/playground/public/moves/knee-flexion.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/lateral.html
+++ b/playground/public/moves/lateral.html
@@ -166,7 +166,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/make-a-fist.html
+++ b/playground/public/moves/make-a-fist.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/mountain-climber.html
+++ b/playground/public/moves/mountain-climber.html
@@ -180,7 +180,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/neck-side-stretch.html
+++ b/playground/public/moves/neck-side-stretch.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/neck.html
+++ b/playground/public/moves/neck.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/overhead-reach.html
+++ b/playground/public/moves/overhead-reach.html
@@ -170,7 +170,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/pinch-grip.html
+++ b/playground/public/moves/pinch-grip.html
@@ -168,7 +168,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/pirouette.html
+++ b/playground/public/moves/pirouette.html
@@ -186,7 +186,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/plank-hold.html
+++ b/playground/public/moves/plank-hold.html
@@ -167,7 +167,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/port-de-bras.html
+++ b/playground/public/moves/port-de-bras.html
@@ -192,7 +192,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/posture.html
+++ b/playground/public/moves/posture.html
@@ -172,7 +172,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/pull-up.html
+++ b/playground/public/moves/pull-up.html
@@ -199,7 +199,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/quad-stretch.html
+++ b/playground/public/moves/quad-stretch.html
@@ -167,7 +167,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/quarter-turns.html
+++ b/playground/public/moves/quarter-turns.html
@@ -196,7 +196,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/releve.html
+++ b/playground/public/moves/releve.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/seated-forward-fold.html
+++ b/playground/public/moves/seated-forward-fold.html
@@ -170,7 +170,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/shoulder-abduction.html
+++ b/playground/public/moves/shoulder-abduction.html
@@ -164,7 +164,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/shoulder-rolls.html
+++ b/playground/public/moves/shoulder-rolls.html
@@ -178,7 +178,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/shoulder.html
+++ b/playground/public/moves/shoulder.html
@@ -166,7 +166,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/sidebend.html
+++ b/playground/public/moves/sidebend.html
@@ -168,7 +168,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/sit-to-stand.html
+++ b/playground/public/moves/sit-to-stand.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/spine-rotation.html
+++ b/playground/public/moves/spine-rotation.html
@@ -175,7 +175,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/squat.html
+++ b/playground/public/moves/squat.html
@@ -176,7 +176,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/step-up.html
+++ b/playground/public/moves/step-up.html
@@ -192,7 +192,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/superman.html
+++ b/playground/public/moves/superman.html
@@ -172,7 +172,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/supine-leg-raise.html
+++ b/playground/public/moves/supine-leg-raise.html
@@ -165,7 +165,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/tendu.html
+++ b/playground/public/moves/tendu.html
@@ -173,7 +173,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/touch-toes.html
+++ b/playground/public/moves/touch-toes.html
@@ -172,7 +172,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/triceps-dips.html
+++ b/playground/public/moves/triceps-dips.html
@@ -197,7 +197,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/twist.html
+++ b/playground/public/moves/twist.html
@@ -182,7 +182,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/walk-cycle.html
+++ b/playground/public/moves/walk-cycle.html
@@ -217,7 +217,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/wall-sit.html
+++ b/playground/public/moves/wall-sit.html
@@ -173,7 +173,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/moves/waltz-box.html
+++ b/playground/public/moves/waltz-box.html
@@ -200,7 +200,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/public/spec.html
+++ b/playground/public/spec.html
@@ -115,9 +115,9 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     </header>
     <main class="wrap">
       <p class="eyebrow">Reference</p>
-<h1>Posecode Protocol Specification — v0.1</h1>
+<h1>Posecode Protocol Specification v0.1</h1>
 <p>Posecode is a small text language for describing a single person's <strong>kinematic movement</strong> so it can be rendered as an animated 3D figure in a web browser.</p>
-<p>It is to human movement what Mermaid is to diagrams: an LLM (or a human) writes a compact, readable document; a client-side parser + renderer turns it into a moving mannequin. The model never produces 3D matrices — it expresses the *semantic phases* of a movement, which it already understands.</p>
+<p>It is to human movement what Mermaid is to diagrams: an LLM (or a human) writes a compact, readable document; a client-side parser + renderer turns it into a moving mannequin. The model never produces 3D matrices: it expresses the *semantic phases* of a movement, which it already understands.</p>
 <ul><li><strong>Version keyword:</strong> documents declare nothing; this is <code>posecode 0.1</code>.</li><li><strong>File extension:</strong> <code>.posecode</code></li><li><strong>Compute model:</strong> generation is pure text (server-cheap); all 3D math runs</li></ul>
 <p>on the client (Three.js). See the project research §6.</p>
 <hr>
@@ -152,7 +152,7 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <tr><td><code>hips</code></td><td><code>hip_left</code>, <code>hip_right</code></td><td>yes</td></tr>
 <tr><td><code>knees</code></td><td><code>knee_left</code>, <code>knee_right</code></td><td>yes</td></tr>
 <tr><td><code>ankles</code></td><td><code>ankle_left</code>, <code>ankle_right</code></td><td>yes</td></tr>
-<tr><td>axial</td><td><code>pelvis</code>, <code>spine</code>, <code>chest</code>, <code>neck</code>, <code>head</code></td><td>—</td></tr>
+<tr><td>axial</td><td><code>pelvis</code>, <code>spine</code>, <code>chest</code>, <code>neck</code>, <code>head</code></td><td>n/a</td></tr>
 <tr><td><code>fingers</code> (or <code>fingers_left</code> / <code>fingers_right</code>)</td><td><code>thumb_*</code>, <code>index_*</code>, <code>middle_*</code>, <code>ring_*</code>, <code>pinky_*</code></td><td>yes</td></tr>
 </tbody></table></div>
 <p>Plural names move both sides symmetrically (left-side bones mirror the Y and Z axes). Use a singular <code>*_left</code> / <code>*_right</code> name to move one side. Each finger is a single curl (<code>flex</code>) joint; the thumb also takes <code>abduct</code>/<code>adduct</code>.</p>
@@ -166,21 +166,21 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <tr><td><code>supinate</code> / <code>pronate</code></td><td>Y</td><td>forearm turn</td></tr>
 <tr><td><code>dorsiflex</code> / <code>plantarflex</code></td><td>X</td><td>ankle up / down</td></tr>
 <tr><td><code>hinge</code></td><td>X</td><td>tip the torso forward over the hips (<code>pelvis</code> only)</td></tr>
-<tr><td><code>hold neutral</code></td><td>—</td><td>keep at rest</td></tr>
+<tr><td><code>hold neutral</code></td><td>n/a</td><td>keep at rest</td></tr>
 </tbody></table></div>
-<p><code>hinge</code> is a <strong>hip hinge</strong>: applied to the <code>pelvis</code>, it pivots the torso forward over the hip line while the legs stay planted and vertical (the renderer counter-rotates the hips). Use it — not spinal <code>flex</code> — for a flat-back forward bend: deadlift, bent-over row, good-morning, or a bow.</p>
+<p><code>hinge</code> is a <strong>hip hinge</strong>: applied to the <code>pelvis</code>, it pivots the torso forward over the hip line while the legs stay planted and vertical (the renderer counter-rotates the hips). Use it, not spinal <code>flex</code>, for a flat-back forward bend: deadlift, bent-over row, good-morning, or a bow.</p>
 <p><strong>Coordinate convention:</strong> rest pose is standing, arms at sides, facing +Z. The renderer's mannequin is built in this same convention so the parser's resolved Euler angles apply directly.</p>
 <hr>
 <h2>4. Range of Motion (safety)</h2>
 <p>Every angle is <strong>hard-clamped</strong> to a healthy Range of Motion before rendering; a clamp emits a warning (it does not fail the parse). Limits follow the research §5.1 normative tables. Selected ceilings (degrees):</p>
 <div class="table-wrap"><table><thead><tr><th>Joint</th><th>flex</th><th>extend</th><th>abduct</th><th>other</th></tr></thead><tbody>
 <tr><td>shoulder</td><td>180</td><td>60</td><td>180</td><td>rot-in 70 / rot-out 90</td></tr>
-<tr><td>elbow</td><td>154</td><td>10</td><td>—</td><td>supinate 92 / pronate 84</td></tr>
-<tr><td>hip</td><td>135</td><td>20</td><td>45</td><td>—</td></tr>
-<tr><td>knee</td><td>144</td><td>5</td><td>—</td><td>—</td></tr>
-<tr><td>ankle</td><td>—</td><td>—</td><td>—</td><td>dorsiflex 15 / plantarflex 50</td></tr>
-<tr><td>pelvis</td><td>—</td><td>—</td><td>—</td><td>hinge 120</td></tr>
-<tr><td>finger</td><td>100</td><td>20</td><td>—</td><td>—</td></tr>
+<tr><td>elbow</td><td>154</td><td>10</td><td>n/a</td><td>supinate 92 / pronate 84</td></tr>
+<tr><td>hip</td><td>135</td><td>20</td><td>45</td><td>n/a</td></tr>
+<tr><td>knee</td><td>144</td><td>5</td><td>n/a</td><td>n/a</td></tr>
+<tr><td>ankle</td><td>n/a</td><td>n/a</td><td>n/a</td><td>dorsiflex 15 / plantarflex 50</td></tr>
+<tr><td>pelvis</td><td>n/a</td><td>n/a</td><td>n/a</td><td>hinge 120</td></tr>
+<tr><td>finger</td><td>100</td><td>20</td><td>n/a</td><td>n/a</td></tr>
 <tr><td>thumb</td><td>80</td><td>20</td><td>50</td><td>adduct 30</td></tr>
 <tr><td>spine</td><td>90</td><td>30</td><td>35</td><td>rotate 45</td></tr>
 <tr><td>neck</td><td>50</td><td>60</td><td>45</td><td>rotate 80</td></tr>
@@ -188,21 +188,21 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <p>&gt; ⚠️ These are general literature values, not medical advice. Consult a &gt; qualified professional for physiotherapy or exercise prescription.</p>
 <hr>
 <h2>5. Rendering model</h2>
-<ol><li><strong>Forward kinematics</strong> — each phase sets joint angles; the renderer slerps</li></ol>
+<ol><li><strong>Forward kinematics</strong>: each phase sets joint angles; the renderer slerps</li></ol>
 <p>bone rotations between phases with the phase's easing.</p>
-<ol><li><strong>Grounding</strong> — the figure is dropped so its lowest point rests on the floor</li></ol>
+<ol><li><strong>Grounding</strong>: the figure is dropped so its lowest point rests on the floor</li></ol>
 <p>(a bounding-box drop), which grounds standing, plank, and the lying/seated poses alike.</p>
-<ol><li><strong>Ground-lock IK</strong> — effectors listed in <code>ground-lock</code> (<code>hands</code>, <code>feet</code>) are</li></ol>
+<ol><li><strong>Ground-lock IK</strong>: effectors listed in <code>ground-lock</code> (<code>hands</code>, <code>feet</code>) are</li></ol>
 <p>pinned to their planted floor position so they stay put while the body moves.</p>
-<ol><li><strong>Reach-IK</strong> — a <code>reach:</code> line drives an effector (`hand_left|hand_right|</li></ol>
-<p>foot_left|foot_right<code>, or the groups </code>hands<code>/</code>feet<code> for both sides) to a world <strong>target</strong> via Cyclic Coordinate Descent (CCD) over the arm/leg chain. A target is a body landmark bone (e.g. </code>ankle_left<code>), the keyword </code>floor<code>, or a prop anchor (</code>bar<code>, </code>seat<code>, </code>wall`). The solve is <strong>ROM-constrained</strong>: each iteration clamps every chain joint into its §4 Range-of-Motion limits (expressed as a per-axis box in the bone's local Euler frame), so a reach toward an unsafe or unreachable target settles on the closest *healthy* pose — solved angles obey the same hard limits as authored ones.</p>
-<ol><li><strong>Props</strong> — <code>prop chair|wall|bar|box|dip-bars</code> adds a scene object at a</li></ol>
+<ol><li><strong>Reach-IK</strong>: a <code>reach:</code> line drives an effector (`hand_left|hand_right|</li></ol>
+<p>foot_left|foot_right<code>, or the groups </code>hands<code>/</code>feet<code> for both sides) to a world <strong>target</strong> via Cyclic Coordinate Descent (CCD) over the arm/leg chain. A target is a body landmark bone (e.g. </code>ankle_left<code>), the keyword </code>floor<code>, or a prop anchor (</code>bar<code>, </code>seat<code>, </code>wall`). The solve is <strong>ROM-constrained</strong>: each iteration clamps every chain joint into its §4 Range-of-Motion limits (expressed as a per-axis box in the bone's local Euler frame), so a reach toward an unsafe or unreachable target settles on the closest *healthy* pose; solved angles obey the same hard limits as authored ones.</p>
+<ol><li><strong>Props</strong>: <code>prop chair|wall|bar|box|dip-bars</code> adds a scene object at a</li></ol>
 <p>fixed default placement (chair/wall behind, bar overhead, box in front, dip bars either side); its named anchors (<code>seat</code>, <code>wall</code>, <code>bar</code>, <code>box</code>, <code>bars</code>) become reach/pin targets.</p>
-<ol><li><strong>Pins</strong> — <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> translates the whole figure so the</li></ol>
-<p>effector sits on the anchor (effectors accept the same <code>hands</code>/<code>feet</code> groups as reach — <code>pin: hands bar</code> pins both). Where ground-lock keeps a foot on the floor and reach moves a limb to a target, a <strong>pin moves the body</strong> while the contact stays put — so the figure hangs from a bar, pulls up toward it, rises onto a box, or lowers into a dip as the joints work.</p>
-<ol><li><strong>Spatial choreography</strong> — <code>turn: &lt;deg&gt;</code> rotates the figure's facing (yaw</li></ol>
-<p>about vertical) and <code>travel: &lt;x&gt; &lt;z&gt;</code> moves it across the floor (world metres from the load spot). Both are <strong>absolute targets carried across phases</strong> (like joint angles) and both return home on the loop wrap, so a box-step traces a square back to start and a pirouette spins a full turn. They layer under grounding (feet still rest on the floor) and power pirouettes, grapevines, traveling combos, and walk cycles. <strong>Standing poses only</strong> — combining with lying/seated bases (whose root is already tilted) is out of scope.</p>
-<ol><li><strong>Looping</strong> — the timeline loops base → phases → base; <code>repeat</code> is the rep</li></ol>
+<ol><li><strong>Pins</strong>: <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> translates the whole figure so the</li></ol>
+<p>effector sits on the anchor (effectors accept the same <code>hands</code>/<code>feet</code> groups as reach: <code>pin: hands bar</code> pins both). Where ground-lock keeps a foot on the floor and reach moves a limb to a target, a <strong>pin moves the body</strong> while the contact stays put, so the figure hangs from a bar, pulls up toward it, rises onto a box, or lowers into a dip as the joints work.</p>
+<ol><li><strong>Spatial choreography</strong>: <code>turn: &lt;deg&gt;</code> rotates the figure's facing (yaw</li></ol>
+<p>about vertical) and <code>travel: &lt;x&gt; &lt;z&gt;</code> moves it across the floor (world metres from the load spot). Both are <strong>absolute targets carried across phases</strong> (like joint angles) and both return home on the loop wrap, so a box-step traces a square back to start and a pirouette spins a full turn. They layer under grounding (feet still rest on the floor) and power pirouettes, grapevines, traveling combos, and walk cycles. <strong>Standing poses only</strong>: combining with lying/seated bases (whose root is already tilted) is out of scope.</p>
+<ol><li><strong>Looping</strong>: the timeline loops base → phases → base; <code>repeat</code> is the rep</li></ol>
 <p>count surfaced to the UI.</p>
 <p><strong>Start poses:</strong> <code>neutral</code>, <code>standing</code>, <code>plank</code>, <code>supine</code> (face-up), <code>prone</code> (face-down), <code>seated</code> (long-sit on the floor).</p>
 <p><strong>IK note:</strong> Three.js's bundled <code>CCDIKSolver</code> targets <code>SkinnedMesh</code>; the Posecode mannequin is rigid capsule segments, so Posecode implements CCD directly over the Object3D bone hierarchy (<code>posecode-render/ik.ts</code>) for both ground-lock and reach. Two-person/dual-IK and collision detection remain deferred (research §5.2, §6.2).</p>
@@ -231,7 +231,7 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/playground/src/editor.ts
+++ b/playground/src/editor.ts
@@ -1,5 +1,5 @@
 /**
- * The Posecode code editor — a CodeMirror 6 setup that turns the plain textarea
+ * The Posecode code editor: a CodeMirror 6 setup that turns the plain textarea
  * into a real editor: syntax highlighting, inline ROM/error squiggles,
  * context-aware autocomplete, and hover docs. All language smarts come from
  * `posecode-language` (shared with the LSP), so the editor never reimplements them.
@@ -208,7 +208,7 @@ const posecodeHoverTip = hoverTooltip((view, pos) => {
     create() {
       const dom = document.createElement("div");
       dom.className = "cm-posecode-hover";
-      // Contents are markdown from our own vocab (no user free-text) — render bold.
+      // Contents are markdown from our own vocab (no user free-text): render bold.
       dom.innerHTML = escapeHtml(info.contents).replace(
         /\*\*(.+?)\*\*/g,
         "<strong>$1</strong>",
@@ -267,7 +267,7 @@ const posecodeTheme = EditorView.theme(
 
 // --- Active-phase highlight -------------------------------------------------
 // As the figure animates, the playground highlights the step block driving the
-// current moment — making the text↔motion mapping visible. Lines are 1-based.
+// current moment, making the text↔motion mapping visible. Lines are 1-based.
 
 const setPhaseHighlight = StateEffect.define<{ from: number; to: number } | null>();
 const phaseLineDeco = Decoration.line({ class: "cm-phase-active" });

--- a/playground/src/landing.ts
+++ b/playground/src/landing.ts
@@ -1,7 +1,7 @@
 /**
  * Posecode landing page. Demo-forward: a live hero viewer and an examples gallery
  * whose cards deep-link into the playground via the shared permalink codec.
- * Reuses the same parser, renderer, and share encoding as the tool — no
+ * Reuses the same parser, renderer, and share encoding as the tool: no
  * bespoke logic that could drift.
  */
 

--- a/playground/src/nice-share.ts
+++ b/playground/src/nice-share.ts
@@ -17,7 +17,7 @@ export function buildNiceShareHash(source: string): string {
   return preset ? `#${SHARE_PARAM}=${preset.id}` : buildShareHash(source);
 }
 
-/** Reverse of buildNiceShareHash. Never throws — an invalid link is just "no shared doc". */
+/** Reverse of buildNiceShareHash. Never throws: an invalid link is just "no shared doc". */
 export function resolveSharedSource(hash: string): string | null {
   if (typeof hash !== "string") return null;
   const raw = hash.startsWith("#") ? hash.slice(1) : hash;

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -14,7 +14,7 @@ import sideBend from "../../spec/examples/side-bend.posecode?raw";
 import deadlift from "../../spec/examples/deadlift.posecode?raw";
 import bentOverRow from "../../spec/examples/bent-over-row.posecode?raw";
 
-// Anatomy / education — single-joint range-of-motion demos.
+// Anatomy / education: single-joint range-of-motion demos.
 import shoulderAbduction from "../../spec/examples/shoulder-abduction-demo.posecode?raw";
 import hipFlexion from "../../spec/examples/hip-flexion-demo.posecode?raw";
 import spineRotation from "../../spec/examples/spine-rotation-demo.posecode?raw";
@@ -71,7 +71,7 @@ import fingerSpell from "../../spec/examples/finger-spell-demo.posecode?raw";
 import handWave from "../../spec/examples/hand-wave.posecode?raw";
 import pinchGrip from "../../spec/examples/pinch-grip.posecode?raw";
 
-// Strength & core (coverage-gap batch — see docs/coverage-gap.md).
+// Strength & core (coverage-gap batch, see docs/coverage-gap.md).
 import plankHold from "../../spec/examples/plank-hold.posecode?raw";
 import mountainClimber from "../../spec/examples/mountain-climber.posecode?raw";
 import crunch from "../../spec/examples/crunch.posecode?raw";
@@ -89,7 +89,7 @@ import pullUp from "../../spec/examples/pull-up.posecode?raw";
 import stepUp from "../../spec/examples/step-up.posecode?raw";
 import tricepsDips from "../../spec/examples/triceps-dips.posecode?raw";
 
-// Spatial choreography (turn & travel) — the figure turns and moves across the floor.
+// Spatial choreography (turn & travel): the figure turns and moves across the floor.
 import pirouette from "../../spec/examples/pirouette.posecode?raw";
 import boxStep from "../../spec/examples/box-step.posecode?raw";
 import grapevine from "../../spec/examples/grapevine.posecode?raw";
@@ -103,7 +103,7 @@ export type Difficulty = "Beginner" | "Intermediate" | "Advanced";
 export interface Preset {
   id: string;
   label: string;
-  /** Use-case domain (Fitness, Dance, Physiotherapy, …) — the primary grouping. */
+  /** Use-case domain (Fitness, Dance, Physiotherapy, …): the primary grouping. */
   domain: string;
   /** Standard fitness taxonomy, so the gallery can filter like an exercise DB. */
   bodyPart: string;

--- a/scripts/generate-content-pages.mjs
+++ b/scripts/generate-content-pages.mjs
@@ -8,7 +8,7 @@
  *   - playground/public/sitemap.xml       regenerated to include all of the above
  *
  * These are plain HTML files copied through as-is by Vite (public/), so this
- * script is *not* wired into `npm run build` — run it manually after adding
+ * script is *not* wired into `npm run build`: run it manually after adding
  * or editing spec/examples/*.posecode, and commit the output. That keeps the
  * production build command (which Vercel runs) simple and low-risk.
  *

--- a/scripts/lib/md.mjs
+++ b/scripts/lib/md.mjs
@@ -2,7 +2,7 @@
  * Minimal Markdown → HTML renderer, scoped to exactly the constructs used in
  * spec/SPEC.md and spec/llm-authoring.md: headers, fenced code blocks, pipe
  * tables, ordered/unordered lists, bold, inline code, links, and hr. Not a
- * general-purpose renderer — deliberately small and dependency-free so the
+ * general-purpose renderer: deliberately small and dependency-free so the
  * doc pages don't pull a markdown library into the build.
  */
 
@@ -14,7 +14,7 @@ function escapeHtml(s) {
     .replace(/"/g, "&quot;");
 }
 
-/** Inline spans: `code`, **bold**, [text](url) — applied to already-escaped text. */
+/** Inline spans: `code`, **bold**, [text](url), applied to already-escaped text. */
 function renderInline(escaped) {
   return escaped
     .replace(/`([^`]+)`/g, "<code>$1</code>")

--- a/scripts/lib/shell.mjs
+++ b/scripts/lib/shell.mjs
@@ -2,7 +2,7 @@
  * Shared HTML shell for statically-generated content pages (movement pages,
  * the library index, doc pages). These live under playground/public/ and are
  * copied through untouched by Vite, so they can't rely on hashed build
- * assets — the theme is a small inlined stylesheet instead, kept close to
+ * assets: the theme is a small inlined stylesheet instead, kept close to
  * the "Kinetic Lab" tokens in playground/src/style.css.
  */
 
@@ -151,7 +151,7 @@ export function pageShell({ title, description, canonicalPath, jsonLd, bodyHtml,
       <div class="wrap">
         <p>Range-of-motion values are general literature data, not medical advice. Consult a
         qualified professional for physiotherapy or exercise prescription.</p>
-        <p><a href="/">Posecode</a> — MIT-licensed open core.</p>
+        <p><a href="/">Posecode</a>, MIT-licensed open core.</p>
       </div>
     </footer>
   </body>

--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -4,9 +4,9 @@
  * disturbing the source-first package.json the monorepo relies on for dev
  * (Vite/vitest/tsc all resolve these packages via "main": "./src/index.ts").
  *
- * npm has no built-in way to swap main/types/exports at publish time (that's
- * a Yarn Berry feature, not npm's — verified empirically: `npm pack` ignores
- * `publishConfig.main/types/exports`). So this script does it by hand: build
+ * npm has no built-in way to swap main/types/exports at publish time. That's
+ * a Yarn Berry feature, not npm's: verified empirically, `npm pack` ignores
+ * `publishConfig.main/types/exports`. So this script does it by hand: build
  * dist/, temporarily rewrite package.json to point at dist/, publish, then
  * always restore the original package.json, even on failure.
  *

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,11 +1,11 @@
-# Posecode Protocol Specification — v0.1
+# Posecode Protocol Specification v0.1
 
 Posecode is a small text language for describing a single person's **kinematic
 movement** so it can be rendered as an animated 3D figure in a web browser.
 
 It is to human movement what Mermaid is to diagrams: an LLM (or a human) writes
 a compact, readable document; a client-side parser + renderer turns it into a
-moving mannequin. The model never produces 3D matrices — it expresses the
+moving mannequin. The model never produces 3D matrices: it expresses the
 *semantic phases* of a movement, which it already understands.
 
 - **Version keyword:** documents declare nothing; this is `posecode 0.1`.
@@ -56,7 +56,7 @@ phase, all joint targets apply concurrently.
 | `hips` | `hip_left`, `hip_right` | yes |
 | `knees` | `knee_left`, `knee_right` | yes |
 | `ankles` | `ankle_left`, `ankle_right` | yes |
-| axial | `pelvis`, `spine`, `chest`, `neck`, `head` | — |
+| axial | `pelvis`, `spine`, `chest`, `neck`, `head` | n/a |
 | `fingers` (or `fingers_left` / `fingers_right`) | `thumb_*`, `index_*`, `middle_*`, `ring_*`, `pinky_*` | yes |
 
 Plural names move both sides symmetrically (left-side bones mirror the Y and Z
@@ -79,11 +79,11 @@ where the previous phase left it).
 | `supinate` / `pronate` | Y | forearm turn |
 | `dorsiflex` / `plantarflex` | X | ankle up / down |
 | `hinge` | X | tip the torso forward over the hips (`pelvis` only) |
-| `hold neutral` | — | keep at rest |
+| `hold neutral` | n/a | keep at rest |
 
 `hinge` is a **hip hinge**: applied to the `pelvis`, it pivots the torso forward
 over the hip line while the legs stay planted and vertical (the renderer
-counter-rotates the hips). Use it — not spinal `flex` — for a flat-back forward
+counter-rotates the hips). Use it, not spinal `flex`, for a flat-back forward
 bend: deadlift, bent-over row, good-morning, or a bow.
 
 **Coordinate convention:** rest pose is standing, arms at sides, facing +Z. The
@@ -101,12 +101,12 @@ research §5.1 normative tables. Selected ceilings (degrees):
 | Joint | flex | extend | abduct | other |
 | --- | --- | --- | --- | --- |
 | shoulder | 180 | 60 | 180 | rot-in 70 / rot-out 90 |
-| elbow | 154 | 10 | — | supinate 92 / pronate 84 |
-| hip | 135 | 20 | 45 | — |
-| knee | 144 | 5 | — | — |
-| ankle | — | — | — | dorsiflex 15 / plantarflex 50 |
-| pelvis | — | — | — | hinge 120 |
-| finger | 100 | 20 | — | — |
+| elbow | 154 | 10 | n/a | supinate 92 / pronate 84 |
+| hip | 135 | 20 | 45 | n/a |
+| knee | 144 | 5 | n/a | n/a |
+| ankle | n/a | n/a | n/a | dorsiflex 15 / plantarflex 50 |
+| pelvis | n/a | n/a | n/a | hinge 120 |
+| finger | 100 | 20 | n/a | n/a |
 | thumb | 80 | 20 | 50 | adduct 30 |
 | spine | 90 | 30 | 35 | rotate 45 |
 | neck | 50 | 60 | 45 | rotate 80 |
@@ -118,14 +118,14 @@ research §5.1 normative tables. Selected ceilings (degrees):
 
 ## 5. Rendering model
 
-1. **Forward kinematics** — each phase sets joint angles; the renderer slerps
+1. **Forward kinematics**: each phase sets joint angles; the renderer slerps
    bone rotations between phases with the phase's easing.
-2. **Grounding** — the figure is dropped so its lowest point rests on the floor
+2. **Grounding**: the figure is dropped so its lowest point rests on the floor
    (a bounding-box drop), which grounds standing, plank, and the lying/seated
    poses alike.
-3. **Ground-lock IK** — effectors listed in `ground-lock` (`hands`, `feet`) are
+3. **Ground-lock IK**: effectors listed in `ground-lock` (`hands`, `feet`) are
    pinned to their planted floor position so they stay put while the body moves.
-4. **Reach-IK** — a `reach:` line drives an effector (`hand_left|hand_right|
+4. **Reach-IK**: a `reach:` line drives an effector (`hand_left|hand_right|
    foot_left|foot_right`, or the groups `hands`/`feet` for both sides) to a
    world **target** via Cyclic Coordinate Descent (CCD) over the arm/leg chain.
    A target is a body landmark bone (e.g. `ankle_left`), the keyword `floor`,
@@ -133,26 +133,26 @@ research §5.1 normative tables. Selected ceilings (degrees):
    each iteration clamps every chain joint into its §4 Range-of-Motion limits
    (expressed as a per-axis box in the bone's local Euler frame), so a reach
    toward an unsafe or unreachable target settles on the closest *healthy*
-   pose — solved angles obey the same hard limits as authored ones.
-5. **Props** — `prop chair|wall|bar|box|dip-bars` adds a scene object at a
+   pose; solved angles obey the same hard limits as authored ones.
+5. **Props**: `prop chair|wall|bar|box|dip-bars` adds a scene object at a
    fixed default placement (chair/wall behind, bar overhead, box in front,
    dip bars either side); its named anchors (`seat`, `wall`, `bar`, `box`,
    `bars`) become reach/pin targets.
-6. **Pins** — `pin: <effector> <anchor>` translates the whole figure so the
+6. **Pins**: `pin: <effector> <anchor>` translates the whole figure so the
    effector sits on the anchor (effectors accept the same `hands`/`feet` groups
-   as reach — `pin: hands bar` pins both). Where ground-lock keeps a foot on
+   as reach: `pin: hands bar` pins both). Where ground-lock keeps a foot on
    the floor and reach moves a limb to a target, a **pin moves the body** while
-   the contact stays put — so the figure hangs from a bar, pulls up toward it,
+   the contact stays put, so the figure hangs from a bar, pulls up toward it,
    rises onto a box, or lowers into a dip as the joints work.
-7. **Spatial choreography** — `turn: <deg>` rotates the figure's facing (yaw
+7. **Spatial choreography**: `turn: <deg>` rotates the figure's facing (yaw
    about vertical) and `travel: <x> <z>` moves it across the floor (world metres
    from the load spot). Both are **absolute targets carried across phases** (like
    joint angles) and both return home on the loop wrap, so a box-step traces a
    square back to start and a pirouette spins a full turn. They layer under
    grounding (feet still rest on the floor) and power pirouettes, grapevines,
-   traveling combos, and walk cycles. **Standing poses only** — combining with
+   traveling combos, and walk cycles. **Standing poses only**: combining with
    lying/seated bases (whose root is already tilted) is out of scope.
-8. **Looping** — the timeline loops base → phases → base; `repeat` is the rep
+8. **Looping**: the timeline loops base → phases → base; `repeat` is the rep
    count surfaced to the UI.
 
 **Start poses:** `neutral`, `standing`, `plank`, `supine` (face-up), `prone`

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -8,7 +8,7 @@ into the Posecode playground.
 
 You write **Posecode**, a small text language that describes a single person's
 movement so a 3D mannequin can animate it. Output ONLY a `.posecode` document in a
-code block — no prose.
+code block, no prose.
 
 ## Grammar
 
@@ -36,15 +36,15 @@ wrists hips knees ankles`. Plural names move both sides symmetrically; use
 
 ## Actions (degrees are absolute targets)
 
-- `flex` / `extend` — bend / straighten (sagittal)
-- `abduct` / `adduct` — away from / toward midline (frontal)
-- `rotate-in` / `rotate-out` — internal / external rotation
-- `supinate` / `pronate` — forearm turn (palm up / down)
-- `dorsiflex` / `plantarflex` — ankle up / down
-- `hinge` — **hip hinge** (on `pelvis` only): tip the torso forward over the
-  hips with a flat back, legs staying planted. Use this — not spinal `flex` —
+- `flex` / `extend`: bend / straighten (sagittal)
+- `abduct` / `adduct`: away from / toward midline (frontal)
+- `rotate-in` / `rotate-out`: internal / external rotation
+- `supinate` / `pronate`: forearm turn (palm up / down)
+- `dorsiflex` / `plantarflex`: ankle up / down
+- `hinge`: **hip hinge** (on `pelvis` only): tip the torso forward over the
+  hips with a flat back, legs staying planted. Use this, not spinal `flex`,
   for a deadlift, bent-over row, good-morning, or a bow.
-- `hold neutral` — keep the joint at rest
+- `hold neutral`: keep the joint at rest
 
 ## Rules
 
@@ -96,7 +96,7 @@ posecode exercise "Deadlift"
     knees: flex 25
     shoulders: flex 90
     ground-lock: feet
-    cue "Hips back, flat back — let the arms hang to the bar"
+    cue "Hips back, flat back: let the arms hang to the bar"
 
   step "Lift" 1.4s ease-out:
     pelvis: hinge 0
@@ -110,14 +110,14 @@ posecode exercise "Deadlift"
 
 ## Reaching, props, lying poses & hands
 
-- **Reach a target** — `reach: <effector> <target>` drives a hand or foot to a
+- **Reach a target**: `reach: <effector> <target>` drives a hand or foot to a
   world point via IK. Effectors: `hand_left hand_right foot_left foot_right`,
   or `hands` / `feet` for both sides at once. Targets: a body landmark bone
   (`ankle_left`, `knee_right`…), `floor`, or a prop anchor (`bar`, `seat`,
-  `wall`). The solve is ROM-constrained — the arm/leg can never exceed the safe
+  `wall`). The solve is ROM-constrained: the arm/leg can never exceed the safe
   joint limits chasing a target, so an out-of-reach target just yields the
   closest healthy pose. Author the gross pose (e.g. a `pelvis: hinge`), then
-  let `reach` finish the hand placement. Example — touch your toes:
+  let `reach` finish the hand placement. Example, touch your toes:
 
   ```posecode
   step "Fold" 2.5s ease-in-out:
@@ -129,33 +129,33 @@ posecode exercise "Deadlift"
     cue "Hinge and reach toward the ankles"
   ```
 
-- **Props** — `prop chair | wall | bar | box | dip-bars` (top level). The chair
+- **Props**: `prop chair | wall | bar | box | dip-bars` (top level). The chair
   sits behind the figure (sit-to-stand, box squat), the wall behind that (wall
   sit), the bar overhead, the box in front (step-ups), and the dip bars either
   side at hip-press height (`pin: hands bars` + elbow flex = triceps dips).
-- **Pins** — `pin: <effector> <anchor>` moves the whole BODY so the effector sits
+- **Pins**: `pin: <effector> <anchor>` moves the whole BODY so the effector sits
   on the anchor (vs `reach`, which moves just the limb). Same effectors as reach,
   including `hands` / `feet`. Use it for hanging and climbing: `pin: hands bar` +
   flexing the elbows = a pull-up; `pin: foot_right box` + straightening the leg =
   a step-up; `pin: hands bars` (dip bars) + bending the elbows = a triceps dip.
-- **Lying / seated** — `pose start = supine | prone | seated` for floor and mat
+- **Lying / seated**: `pose start = supine | prone | seated` for floor and mat
   work (glute bridge, dead bug, cobra, seated forward fold).
-- **Hands** — `fingers: flex 80` makes a fist; curl individual fingers for shapes
-  (`index_right: flex 95`). Single-DOF per finger — good for grip and rough
+- **Hands**: `fingers: flex 80` makes a fist; curl individual fingers for shapes
+  (`index_right: flex 95`). Single-DOF per finger, good for grip and rough
   gesture, not exact sign language.
 
 ## Authoring by domain
 
 The same grammar covers many fields. A few patterns that read well:
 
-- **Anatomy / education** — isolate one joint and sweep it through its range
+- **Anatomy / education**: isolate one joint and sweep it through its range
   (`shoulders: abduct 160` → `0`). Name the plane in the cue. Great for teaching.
-- **Physiotherapy** — gentle, single-joint reps; for one-sided work use a
+- **Physiotherapy**: gentle, single-joint reps; for one-sided work use a
   singular joint (`knee_right: flex 95`) and skip `ground-lock` so the standing
   leg stays planted.
-- **Desk / posture** — slow `stretch` documents with `ground-lock: feet`;
+- **Desk / posture**: slow `stretch` documents with `ground-lock: feet`;
   contrast a "collapsed" phase with a "tall" reset.
-- **Sports / martial arts** — short, snappy phases (0.3–0.6s) with `ease-out`
+- **Sports / martial arts**: short, snappy phases (0.3–0.6s) with `ease-out`
   on the strike; chamber → extend → re-chamber → return.
 
 ### Dance / choreography
@@ -181,6 +181,6 @@ Both `turn` and `travel` are **absolute and carried forward** like joint angles,
 and both return home on the loop wrap, so phrases resolve cleanly. They work from
 **standing** poses only. Name each step by its count (`"5-6 - relevé, arms en
 haut"`) so the phrase reads like choreography. To extend a phrase, append more
-steps — the figure carries its pose forward. Use `ground-lock: feet` for grounded
-phrases (it still lets the figure turn and travel — it only keeps the feet on the
+steps; the figure carries its pose forward. Use `ground-lock: feet` for grounded
+phrases (it still lets the figure turn and travel; it only keeps the feet on the
 floor vertically).


### PR DESCRIPTION
Extends the earlier landing-page cleanup to everywhere else: README.md,
ROADMAP.md, VERCEL_AGENTS.md, both docs/ files, every package.json
description, every packages/*/README.md, and every source/test file comment
in packages/* and playground/src.

A few things worth flagging:

- packages/posecode-language/src/{diagnostics,hover,vocab}.ts had em dashes
  in strings that actually render to users: the ROM-clamp warning message,
  hover tooltips, and completion docs shown live in the playground editor and
  VS Code. Verified the fix by triggering a real out-of-range warning in a
  browser; the message now reads clean.
- spec/SPEC.md and spec/llm-authoring.md needed care around table cells that
  use "—" as an "n/a" placeholder (replaced with the literal text "n/a") vs.
  prose em dashes (replaced with a colon, comma, or parens depending on
  context). Regenerated the 72 movement pages + spec/LLM-guide pages afterward
  so the rendered site picks up both the source fix and the shared footer
  template fix (scripts/lib/shell.mjs) that was the single point of failure
  for the em dash showing up on every generated page.
- Left one em dash alone on purpose: packages/posecode-share/test/share.test.ts
  has a test literally named "round-trips Unicode (degree signs, curly
  quotes)" using an em dash as deliberate test fixture data for the UTF-8
  codec. Changing it would remove real coverage for no reason.

Verified with a full typecheck, the 188-test suite, a production build, and a
Playwright pass over the built site (movement pages, spec page, and the live
ROM-warning UI).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B7RkyiTt9soiYdw5vt6BEP