### PR TITLE
perf: lazy-load the CodeMirror editor off the playground critical path

### DIFF
--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -11,7 +11,7 @@ import { parse } from "posecode-parser";
 import { inject } from "@vercel/analytics";
 import type { Viewer } from "posecode-render";
 import { buildNiceShareHash, resolveSharedSource } from "./nice-share.js";
-import { createPosecodeEditor, type PosecodeEditor } from "./editor.js";
+import type { PosecodeEditor } from "./editor.js";
 import { PRESETS } from "./presets.js";
 import { renderWarnings } from "./warnings.js";
 import llmPrompt from "../../spec/llm-authoring.md?raw";
@@ -21,7 +21,10 @@ inject();
 const $ = <T extends HTMLElement>(id: string): T =>
   document.getElementById(id) as T;
 
-let editorApi: PosecodeEditor; // assigned at boot, once the initial doc is known
+// CodeMirror is heavy too, so the editor is lazy-loaded after first paint (its
+// own chunk). Until that resolves, `editorApi` is null; recompile() and the
+// user-action handlers guard on it (a click in that ~tens-of-ms window no-ops).
+let editorApi: PosecodeEditor | null = null;
 const warnings = $<HTMLDivElement>("warnings");
 const canvas = $<HTMLCanvasElement>("canvas");
 const playpause = $<HTMLButtonElement>("playpause");
@@ -156,7 +159,11 @@ function scheduleRecompile(): void {
 
 function recompile(): void {
   window.clearTimeout(debounce); // cancel any pending run; we're compiling now
-  const source = editorApi.getValue();
+  // Captured once so control-flow narrowing survives the calls below; a null
+  // editor (still loading) means there's nothing to compile yet.
+  const ed = editorApi;
+  if (!ed) return;
+  const source = ed.getValue();
   if (!source.trim()) {
     // A deliberately blank editor (the "New" flow): a paste target, not an
     // error state. Show a hint instead of parse errors and stop the playback.
@@ -181,10 +188,10 @@ function recompile(): void {
     updateReps();
     buildRibbonAndMarkers();
     phaseRanges = computePhaseRanges(
-      editorApi.getValue(),
+      ed.getValue(),
       (tl?.segments ?? []).map((s) => s.name),
     );
-    editorApi.highlightPhase(null); // next onPhase paints the active block
+    ed.highlightPhase(null); // next onPhase paints the active block
   }
 }
 
@@ -326,7 +333,7 @@ function loadPreset(id: string): void {
   if (!preset) return;
   currentPresetId = preset.id;
   libCurrent.textContent = preset.label;
-  editorApi.setValue(preset.source);
+  editorApi?.setValue(preset.source);
   recompile();
   setMobileView("viewer"); // on phones, jump to the figure after picking
 }
@@ -345,10 +352,10 @@ renderLibraryList();
 $<HTMLButtonElement>("new-doc").addEventListener("click", () => {
   currentPresetId = null;
   libCurrent.textContent = "New movement";
-  editorApi.setValue("");
+  editorApi?.setValue("");
   recompile(); // swaps the status row to the blank-editor hint immediately
   setMobileView("editor"); // the paste target, front and center on phones
-  editorApi.focus();
+  editorApi?.focus();
 });
 
 // --- Mobile Editor/Viewer toggle (no-op visually on desktop, where both show) ---
@@ -402,6 +409,7 @@ copyBtn.addEventListener("click", () => copyPrompt(copyBtn));
 // Snapshot the current document into a URL hash, reflect it in the address bar
 // (so it's bookmarkable), and copy the full link to the clipboard.
 async function shareLink(): Promise<void> {
+  if (!editorApi) return; // editor still loading; nothing to snapshot yet
   try {
     const hash = buildNiceShareHash(editorApi.getValue());
     const url = `${location.origin}${location.pathname}${hash}`;
@@ -483,17 +491,21 @@ if (sharedSource) {
   libCurrent.textContent = PRESETS[0]!.label;
 }
 
-editorApi = createPosecodeEditor($("editor"), {
-  doc: initialDoc,
-  onChange: scheduleRecompile,
-});
-// Parse + surface warnings immediately so the editor is useful at first paint,
-// even though the 3D figure appears a beat later once the renderer chunk loads.
-recompile();
+// Boot the two heavyweights (CodeMirror editor + Three.js renderer) after the
+// shell paints, each in its own lazy chunk, so neither is on the critical path.
+// They load independently; recompile() self-guards until both are ready, and
+// whichever resolves last triggers the parse-and-animate pass.
 
-// Boot the renderer after first paint: dynamic import keeps Three.js off the
-// critical path (its own chunk), mirroring the landing page. Once the viewer
-// exists we wire its callbacks and recompile so the current doc animates.
+// Editor: mount CodeMirror into the shell, then compile so warnings surface.
+void import("./editor.js").then(({ createPosecodeEditor }) => {
+  editorApi = createPosecodeEditor($("editor"), {
+    doc: initialDoc,
+    onChange: scheduleRecompile,
+  });
+  recompile();
+});
+
+// Renderer: keep Three.js off the critical path, mirroring the landing page.
 void import("posecode-render").then(({ createViewer }) => {
   viewer = createViewer(canvas);
   // Exposed for capture/e2e tooling (frame capture drives README GIFs).


### PR DESCRIPTION
## What

Lazy-loads the CodeMirror editor in the playground (`/play`) so it no longer sits on the initial critical path — via dynamic `import()` after first paint, mirroring how the Three.js renderer already loads.

## Why

`/play` scored lower than the landing page on Lighthouse mobile. `main.ts` statically imported both CodeMirror **and** the renderer, so the entry chunk carried ~900 kB. A prior change (already on `main`) deferred Three.js; this finishes the split by moving CodeMirror into its own lazy chunk.

## Measured impact (honest A/B, localhost, identical throttling)

Critical-path entry chunk shrinks dramatically:

| Chunk | Before | After |
|---|---|---|
| `play` entry (critical path) | **372 kB** (122 kB gzip) | **7.9 kB** (3.3 kB gzip) |
| `editor` (CodeMirror) | *(in entry)* | 365 kB — now lazy |
| renderer (Three.js) | 533 kB — lazy | 533 kB — lazy |

Lighthouse (mobile, localhost, one run each):

| Metric | Before | After |
|---|---|---|
| Performance score | 63 | 63 |
| First Contentful Paint | 5.0 s | **4.2 s** |
| Speed Index | 5.0 s | **4.2 s** |
| Largest Contentful Paint | 7.6 s | 7.9 s |
| Total Blocking Time | 50 ms | 170 ms (noise; both green) |
| CLS | 0.007 | 0.007 |

**What this does and doesn't do:** code-splitting reduces the critical-path *download*, so it helps **FCP / Speed Index** (the shell paints before 365 kB of editor JS arrives) — most on real throttled mobile networks. It does **not** reduce Total Blocking Time, because the editor is still `import()`ed immediately at boot and executes right after paint. The overall score was flat on localhost (where downloads are ~instant); the real-network benefit is expected to be a modest FCP/LCP improvement, not a TBT win.

## Correctness

`editorApi` is nullable until its chunk resolves:
- `recompile()` captures it once (control-flow narrowing survives the intervening calls) and returns early when null.
- User-action handlers (library pick, **New**, **Share**) optional-chain / guard, so a click during the ~tens-of-ms load window safely no-ops.
- The two dynamic imports resolve independently; `recompile()` self-guards so either ordering is safe.

## Verification

- `tsc --noEmit` passes; production build succeeds.
- Verified in-browser (Vite dev): editor mounts, figure animates (timeline built), phase ribbon populates, warnings surface, and library pick / **New** / play-pause work with zero console errors.

## Reviewer note

Single-file change (`playground/src/main.ts`), no behavioral change — only *when* the editor JS executes. Reasonable to merge as an incremental FCP/Speed-Index improvement with no regression; not a dramatic score jump. If chasing TBT specifically, the lever is reducing/deferring *execution* (e.g. idle-callback boot), which trades off editor readiness.