### PR TITLE
fix: run reach-IK before the floor safety clamp (levitating cobra)

### DIFF
--- a/packages/posecode-render/src/index.ts
+++ b/packages/posecode-render/src/index.ts
@@ -346,8 +346,12 @@ export function createViewer(
     effector: THREE.Object3D,
   ): THREE.Vector3 | null {
     if (target === "floor") {
+      // Rest the effector's MESH on the floor, not its bone origin: the hand
+      // mesh extends below the wrist bone, so a bone target of y=0 would sink
+      // the palm and force the floor safety clamp to lift the whole body.
       const p = effector.getWorldPosition(new THREE.Vector3());
-      p.y = 0;
+      const box = new THREE.Box3().setFromObject(effector);
+      p.y = Number.isFinite(box.min.y) ? Math.max(0, p.y - box.min.y) : 0;
       return p;
     }
     const anchor = propAnchors.get(target);
@@ -458,6 +462,14 @@ export function createViewer(
       depenetrate(mannequin);
       applyGroundLockTo(mannequin, info.groundLock, frameAnchors(info.rootYaw, info.rootOffset));
       applyPins(info.pins);
+      // Reach-IK BEFORE the floor safety clamp. When authored FK pushes a
+      // reaching limb through the floor (cobra: prone + shoulders flex 50),
+      // the limb must bend to meet the floor. Running reaches after the clamp
+      // let the clamp "solve" the penetration first by hoisting the whole
+      // rigid body into the air — legs floating, the classic levitating-cobra
+      // bug. Ground-lock and pins have already fixed the root placement that
+      // floor/landmark targets resolve against.
+      applyReaches(info.reaches);
       // Safety net: nothing above ever intentionally pushes part of the body
       // below the floor, so clamp the root up whenever the lowest point dips
       // below y=0, a no-op whenever the pose is legitimately grounded or
@@ -473,7 +485,6 @@ export function createViewer(
         mannequin.root.position.y -= box.min.y;
         mannequin.root.updateMatrixWorld(true);
       }
-      applyReaches(info.reaches);
       if (info.phaseName !== lastPhaseName) {
         lastPhaseName = info.phaseName;
         phaseCb({ phaseName: info.phaseName, ...(info.cue ? { cue: info.cue } : {}) });


### PR DESCRIPTION
## Description

From a prone base, an authored reaching pose — cobra's `shoulders: flex 50` + `reach: hands floor` — swings the arms through the floor via FK. The viewer frame loop applied its floor safety clamp **before** reach-IK, so the clamp resolved the penetration the only way it can: by hoisting the entire rigid body upward until the hands cleared the floor. The pelvis and legs levitated in mid-air, making cobra (and any prone/seated movement that reaches for the floor) physically impossible-looking.

Two changes in `packages/posecode-render/src/index.ts`:

- **Reach-IK now runs after ground-lock/pins but before the floor clamp.** Reaching limbs bend down to meet the floor first, so the clamp becomes a no-op for legitimately grounded poses instead of lifting the whole body over a penetrating limb.
- **The `floor` reach target is mesh-aware.** It now rests the visible palm on the floor rather than driving the wrist *bone* to y=0; the hand mesh extends below the bone, and the old target left the mesh sunk, forcing a residual whole-body lift from the clamp.

Verified in the playground: cobra now keeps pelvis/legs planted while the chest lifts; mountain climber (hands+feet ground-lock) and superman (prone, clamp-only path) are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Movement/Preset addition (adding a new `.posecode` script and registering it)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my own code
- My changes generate no new TypeScript/compiler warnings or errors:
  - [x] Running `npm run typecheck` passes successfully
  - [x] Running `npm run build` compiles without errors
- [x] I have run the unit test suite (`npm test`) and all tests pass (194/194)
- [x] If applicable, I have run the fidelity evals (`npm run eval`) and all checks pass (361/361, 73 movements, 0 clamp warnings)
- [ ] If I added a new movement, I ran `node scripts/generate-content-pages.mjs` to regenerate the static pages (N/A)