### PR TITLE
fix: correct biomechanical form across 14 movements

### DIFF
--- a/spec/examples/bent-over-row.posecode
+++ b/spec/examples/bent-over-row.posecode
@@ -5,20 +5,20 @@ posecode exercise "Bent-over row"
   step "Set the hinge" 1.6s ease-in-out:
     pelvis: hinge 70
     knees: flex 20
-    shoulders: extend 55
+    shoulders: flex 65
     elbows: flex 10
     neck: extend 12
     ground-lock: feet
     cue "Hinge to a flat back, let the arms hang straight down"
 
   step "Row" 0.9s ease-out:
-    shoulders: extend 15
+    shoulders: extend 10
     elbows: flex 95
     ground-lock: feet
     cue "Drive the elbows up past the ribs, squeeze the shoulder blades"
 
   step "Lower" 1s ease-in:
-    shoulders: extend 55
+    shoulders: flex 65
     elbows: flex 10
     ground-lock: feet
     cue "Lower the bar under control, keep the back flat"
@@ -26,7 +26,7 @@ posecode exercise "Bent-over row"
   step "Stand" 1s ease-out:
     pelvis: hinge 0
     knees: flex 0
-    shoulders: extend 0
+    shoulders: flex 0
     elbows: flex 0
     neck: extend 0
     ground-lock: feet

--- a/spec/examples/bicycle-crunch.posecode
+++ b/spec/examples/bicycle-crunch.posecode
@@ -13,22 +13,25 @@ posecode exercise "Bicycle crunch"
 
   step "Right to left" 0.8s ease-in-out:
     spine: rotate-out 20
+    chest: rotate-out 12
     hip_left: flex 110
     knee_left: flex 90
-    hip_right: flex 25
-    knee_right: flex 20
+    hip_right: flex 15
+    knee_right: flex 5
     cue "Right elbow toward the left knee; the right leg extends long"
 
   step "Left to right" 0.8s ease-in-out:
     spine: rotate-in 20
+    chest: rotate-in 12
     hip_right: flex 110
     knee_right: flex 90
-    hip_left: flex 25
-    knee_left: flex 20
+    hip_left: flex 15
+    knee_left: flex 5
     cue "Switch: left elbow toward the right knee"
 
   step "Center" 0.6s ease-out:
     spine: rotate-in 0
+    chest: rotate-in 0
     hip_right: flex 90
     knee_right: flex 90
     hip_left: flex 90

--- a/spec/examples/box-squat.posecode
+++ b/spec/examples/box-squat.posecode
@@ -7,7 +7,8 @@ posecode exercise "Box squat"
     hips: flex 85
     knees: flex 90
     ankles: dorsiflex 12
-    spine: flex 10
+    pelvis: hinge 20
+    spine: flex 0
     shoulders: flex 70
     ground-lock: feet
     cue "Push the hips back and sit lightly onto the box"
@@ -16,6 +17,7 @@ posecode exercise "Box squat"
     hips: flex 0
     knees: flex 0
     ankles: dorsiflex 0
+    pelvis: hinge 0
     spine: flex 0
     shoulders: flex 0
     ground-lock: feet

--- a/spec/examples/chair-pose.posecode
+++ b/spec/examples/chair-pose.posecode
@@ -7,7 +7,8 @@ posecode posture "Chair pose"
     knees: flex 70
     ankles: dorsiflex 12
     shoulders: flex 170
-    spine: flex 10
+    pelvis: hinge 15
+    spine: extend 5
     ground-lock: feet
     cue "Sit the hips back and down, reach the arms overhead"
 
@@ -16,7 +17,8 @@ posecode posture "Chair pose"
     knees: flex 0
     ankles: dorsiflex 0
     shoulders: flex 0
-    spine: flex 0
+    pelvis: hinge 0
+    spine: extend 0
     ground-lock: feet
     cue "Press through the feet to stand, arms float down"
 

--- a/spec/examples/crunch.posecode
+++ b/spec/examples/crunch.posecode
@@ -7,7 +7,7 @@ posecode exercise "Crunch"
     knees: flex 90
     spine: flex 30
     chest: flex 20
-    neck: flex 20
+    neck: flex 8
     shoulders: flex 45
     ground-lock: feet
     cue "Curl the shoulders off the floor, ribs toward the hips"

--- a/spec/examples/dead-bug.posecode
+++ b/spec/examples/dead-bug.posecode
@@ -10,8 +10,8 @@ posecode exercise "Dead bug"
 
   step "Extend right arm & left leg" 1.2s ease-in-out:
     shoulder_right: flex 150
-    hip_left: flex 25
-    knee_left: flex 30
+    hip_left: flex 20
+    knee_left: flex 5
     cue "Lower the right arm overhead and the left leg toward the floor"
 
   step "Switch" 1.2s ease-in-out:
@@ -19,8 +19,8 @@ posecode exercise "Dead bug"
     hip_left: flex 90
     knee_left: flex 90
     shoulder_left: flex 150
-    hip_right: flex 25
-    knee_right: flex 30
+    hip_right: flex 20
+    knee_right: flex 5
     cue "Return and switch: left arm and right leg reach out"
 
   step "Return" 1s ease-out:

--- a/spec/examples/forward-lunge.posecode
+++ b/spec/examples/forward-lunge.posecode
@@ -6,9 +6,10 @@ posecode exercise "Forward lunge"
     hip_right: flex 45
     knee_right: flex 95
     hip_left: extend 15
-    knee_left: flex 45
+    knee_left: flex 80
     ankle_right: dorsiflex 14
     spine: extend 4
+    travel: 0 0.3
     ground-lock: feet
     cue "Step forward and lower the back knee toward the floor"
 
@@ -19,6 +20,7 @@ posecode exercise "Forward lunge"
     knee_left: flex 0
     ankle_right: dorsiflex 0
     spine: flex 0
+    travel: 0 0
     ground-lock: feet
     cue "Push through the front heel to stand tall"
 

--- a/spec/examples/glute-bridge.posecode
+++ b/spec/examples/glute-bridge.posecode
@@ -4,7 +4,7 @@ posecode exercise "Glute bridge"
 
   step "Bridge up" 1.6s ease-out:
     knees: flex 90
-    hips: extend 15
+    hips: extend 20
     spine: extend 10
     ground-lock: feet
     cue "Press through the feet and lift the hips toward the ceiling"

--- a/spec/examples/pull-up.posecode
+++ b/spec/examples/pull-up.posecode
@@ -16,7 +16,7 @@ posecode exercise "Pull-up"
     cue "Hang from the bar, arms long, shoulders active"
 
   step "Pull up" 1.2s ease-out:
-    shoulders: flex 150
+    shoulders: flex 105
     elbows: flex 130
     pin: hands bar
     cue "Pull the chest toward the bar, driving the elbows down"

--- a/spec/examples/seated-forward-fold.posecode
+++ b/spec/examples/seated-forward-fold.posecode
@@ -3,13 +3,15 @@ posecode stretch "Seated forward fold"
   pose start = seated
 
   step "Fold" 3s ease-in-out:
-    spine: flex 60
-    chest: flex 25
-    neck: flex 15
+    hips: flex 115
+    spine: flex 25
+    chest: flex 15
+    neck: flex 10
     shoulders: flex 60
     cue "Hinge forward from the hips over the legs, reaching toward the feet"
 
   step "Rise" 2.5s ease-in-out:
+    hips: flex 90
     spine: flex 0
     chest: flex 0
     neck: flex 0

--- a/spec/examples/single-leg-calf-raise.posecode
+++ b/spec/examples/single-leg-calf-raise.posecode
@@ -5,11 +5,13 @@ posecode exercise "Single-leg calf raise"
   step "Rise" 1.1s ease-out:
     ankle_right: plantarflex 40
     knee_left: flex 90
+    ground-lock: feet
     cue "Balance on the right foot and rise onto the ball of the foot"
 
   step "Lower" 1.3s ease-in:
     ankle_right: plantarflex 0
     knee_left: flex 90
+    ground-lock: feet
     cue "Lower the right heel slowly under control"
 
   repeat 10

--- a/spec/examples/squat.posecode
+++ b/spec/examples/squat.posecode
@@ -6,7 +6,8 @@ posecode exercise "Body-weight squat"
     hips: flex 80
     knees: flex 95
     ankles: dorsiflex 14
-    spine: flex 20
+    pelvis: hinge 25
+    spine: flex 0
     shoulders: flex 70
     neck: extend 10
     ground-lock: feet
@@ -16,6 +17,7 @@ posecode exercise "Body-weight squat"
     hips: flex 0
     knees: flex 0
     ankles: dorsiflex 0
+    pelvis: hinge 0
     spine: flex 0
     shoulders: flex 0
     neck: extend 0

--- a/spec/examples/standing-hamstring-curl.posecode
+++ b/spec/examples/standing-hamstring-curl.posecode
@@ -4,10 +4,12 @@ posecode exercise "Standing hamstring curl"
 
   step "Curl" 1.4s ease-out:
     knee_right: flex 95
+    ground-lock: feet
     cue "Bend the right knee, drawing the heel toward the glute"
 
   step "Lower" 1.6s ease-in:
     knee_right: flex 0
+    ground-lock: feet
     cue "Lower the foot back to the floor"
 
   repeat 10

--- a/spec/examples/standing-quad-stretch.posecode
+++ b/spec/examples/standing-quad-stretch.posecode
@@ -6,11 +6,13 @@ posecode stretch "Standing quad stretch"
     knee_right: flex 144
     hip_right: extend 20
     reach: hand_right ankle_right
+    ground-lock: feet
     cue "Bend the right knee back and reach the hand for the ankle"
 
   step "Release" 2s ease-out:
     knee_right: flex 0
     hip_right: extend 0
+    ground-lock: feet
     cue "Release the foot and return to standing"
 
   repeat 2


### PR DESCRIPTION
## Description

Applies form corrections surfaced by a movement-library review (analyzed with an external LLM, then verified against the actual DSL grammar, ROM tables, and the live renderer before applying). I rejected the report's suggestions that were factually wrong for this codebase — details below.

### What changed

**Neutral spine under load** (the report's strongest, correct point):
- `squat`, `box-squat`, `chair-pose`: replaced lumbar rounding (`spine: flex`) with a `pelvis: hinge` + neutral / slightly-extended spine. The forward lean now comes from the hips, not a rounded back — real athletic squat form. Verified in the viewer: torso is upright, chest proud.

**Lunge reads as a lunge, not a static split squat:**
- `forward-lunge`: deepened the trailing knee (`flex 45 → 80`) and added a small `travel: 0 0.3`. Verified: the back knee now drops toward the floor.

**Arms hang / pull correctly:**
- `bent-over-row`: `shoulders: extend 55` (arms thrown *backward*) → `shoulders: flex 65`, which over a 70° hinge hangs the arms vertically; the row pull uses `extend 10`.
- `pull-up`: pull the shoulders down toward the bar during the pull (`flex 150 → 105`) instead of holding them locked overhead.

**Straighter 'long' limbs + cleaner detail:**
- `crunch`: `neck: flex 20 → 8` (less chin-tuck).
- `seated-forward-fold`: hinge at the hips (`flex 90 → 115`), cut `spine: flex 60 → 25` so it folds instead of slouching from the mid-back.
- `bicycle-crunch`, `dead-bug`: straighten the extended leg (`knee ≈ 5`) and add chest counter-rotation so the twist reads.
- `glute-bridge`: `hips: extend 15 → 20`.

**Supporting-foot planting:**
- `single-leg-calf-raise`, `standing-hamstring-curl`, `standing-quad-stretch`: added `ground-lock: feet` so the stance foot stays planted.

### Where I disagreed with the report

- **"Flying cobra / floating body" is not a data problem.** The report blamed missing `pin` on the floor exercises. The real cause was solver ordering (floor safety clamp running before reach-IK) — already fixed separately in #27. So I did **not** add the report's `pin: hips floor` / `pin: pelvis floor` lines (there is no `floor` pin anchor in the renderer; pins resolve against props/landmarks, and floor grounding is handled by `ground-lock` + the clamp).
- **`ground-lock: foot_left` is invalid DSL.** `ground-lock` only accepts the effector *groups* `hands`/`feet` (resolved via `mannequin.effectors`); a bare `foot_left` resolves to nothing. So mountain-climber's per-foot suggestion wouldn't work as written, and supporting-foot locks here use the `feet` group, which the renderer already filters to only plant feet near the floor.
- **Mountain climber is not broken.** With `ground-lock: hands, feet`, the driving foot lifts off the floor (hip/knee flex), so the near-floor planted-foot filter naturally excludes it — it isn't frozen. Left unchanged.
- Skipped cosmetic-only score nudges (wall-sit arm position, etc.) that don't affect correctness.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Self-reviewed
- [x] `npm run typecheck` passes
- [x] `npm run build` compiles
- [x] `npm test` — 194/194 pass
- [x] `npm run eval` — 361/361 checks, 73 movements, 0 parse failures, 0 clamp warnings
- [x] Spot-checked squat and forward-lunge in the live viewer