### PR TITLE
Prepare Posecode 0.2 for third-party embeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Build publishable packages
+        run: npm run build:packages
+
       - name: Build playground
         run: npm run build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-15
+
 ### Added
 
+- **Canonical timing modes**: `flow`, `settle`, `drive`, `snap`, and `linear`
+  now describe continuous motion, deliberate rests, acceleration, and sharp
+  arrivals. The v0.1 easing spellings remain accepted as deprecated aliases.
+- **Third-party validation CLI**: `npx posecode-parser@0.2.0 validate <path>`
+  recursively checks `.posecode` libraries, with `--strict` and `--json` modes
+  for CI.
+- **Embed compatibility metadata**: the CDN bundle exports `version`,
+  `languageVersion`, and `validatePosecode()`. Player ready/error events now
+  include structured version and diagnostic details, while host elements expose
+  a machine-readable loading/ready/error state.
+- **Release contract checks**: CI builds the publishable package chain so a
+  source-only language change cannot land without a valid CDN bundle.
 - **Realistic human figure**: the playground, landing hero, and `<posecode-player>` embeds now render a fully rigged, textured human character (hands with articulated fingers, sneakers, face) instead of the procedural capsule mannequin. All solving (FK, ground-lock, pins, reach-IK) still runs on the driver skeleton, rebuilt to the character's exact proportions and retargeted bone-for-bone every frame; the procedural figure remains as an automatic fallback (and via `?figure=classic` / `character="off"`).
 - **Self-collision resolution**: a capsule-based de-penetration pass keeps forearms/hands out of the torso, head, and legs (and shins out of each other), clamped to healthy ROM, so limbs no longer pass through the body mid-movement.
 - **Solid props**: props now declare blocking faces (the wall's surface, the chair's backrest and seat edge, the box's near face) and a contact pass keeps the body out of them — translating the whole figure along the face normal, or bending the offending leg's hip clear (ROM-clamped). Limbs pinned/gripped/reached to a prop anchor stay exempt as declared support. A new `solid-props` eval invariant (independent geometry re-derivation) guards every prop movement against this bug class.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ A `.posecode` file describes movement as timed phases with targeted joint action
 
 | 1. Write `.posecode` | 2. Render the movement |
 | :--- | :--- |
-| **`posecode`** `exercise "Body-weight squat"`<br />**`rig`** `humanoid`<br />**`pose`** `start = standing`<br /><br />**`step`** `"Descend" 1.6s ease-in-out`:<br />&nbsp;&nbsp;`hips: flex 80`<br />&nbsp;&nbsp;`knees: flex 95`<br />&nbsp;&nbsp;`ankles: dorsiflex 14`<br />&nbsp;&nbsp;`ground-lock: feet`<br />&nbsp;&nbsp;`cue "Sit the hips back"`<br /><br />**`step`** `"Drive up" 1.2s ease-out`:<br />&nbsp;&nbsp;`hips: flex 0`<br />&nbsp;&nbsp;`knees: flex 0`<br />&nbsp;&nbsp;`ankles: dorsiflex 0`<br />&nbsp;&nbsp;`ground-lock: feet`<br /><br />**`repeat`** `8` | <img src="docs/media/squat.gif" width="340" alt="Squat animation" /> |
+| **`posecode`** `exercise "Body-weight squat"`<br />**`rig`** `humanoid`<br />**`pose`** `start = standing`<br /><br />**`step`** `"Descend" 1.6s settle`:<br />&nbsp;&nbsp;`hips: flex 80`<br />&nbsp;&nbsp;`knees: flex 95`<br />&nbsp;&nbsp;`ankles: dorsiflex 14`<br />&nbsp;&nbsp;`ground-lock: feet`<br />&nbsp;&nbsp;`cue "Sit the hips back"`<br /><br />**`step`** `"Drive up" 1.2s drive`:<br />&nbsp;&nbsp;`hips: flex 0`<br />&nbsp;&nbsp;`knees: flex 0`<br />&nbsp;&nbsp;`ankles: dorsiflex 0`<br />&nbsp;&nbsp;`ground-lock: feet`<br /><br />**`repeat`** `8` | <img src="docs/media/squat.gif" width="340" alt="Squat animation" /> |
 
 ---
 
@@ -355,33 +355,31 @@ npm install posecode-render
 Example:
 
 ```ts
-import { parsePosecode } from "posecode-parser";
-import { PosecodeRenderer } from "posecode-render";
+import { parse } from "posecode-parser";
+import { createViewer } from "posecode-render";
 
 const source = `
-exercise "Lateral raise"
-rig humanoid
-pose start = standing
+posecode exercise "Lateral raise"
+  rig humanoid
+  pose start = standing
 
-step "Raise" 1.4s ease-in-out:
-  shoulders: abduct 90
+  step "Raise" 1.4s settle:
+    shoulders: abduct 90
 `;
 
-const result = parsePosecode(source);
+const { ir, errors, warnings } = parse(source);
 
-if (!result.ok) {
-  console.error(result.errors);
+if (!ir || errors.length > 0) {
+  console.error(errors);
 } else {
-  const renderer = new PosecodeRenderer({
-    container: document.querySelector("#viewer"),
-  });
-
-  renderer.load(result.document);
-  renderer.play();
+  console.warn(warnings);
+  const viewer = createViewer(document.querySelector("#viewer"));
+  viewer.load(ir);
+  viewer.play();
 }
 ```
 
-> Adjust this example to match the current exported APIs before submission.
+The `#viewer` element is an HTML `<canvas>`.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ We actively support and fix security issues in the following versions of Posecod
 
 | Version | Supported |
 | ------- | --------- |
-| v0.1.x  | Yes       |
+| v0.2.x  | Yes       |
+| v0.1.x  | Security fixes only |
 
 ---
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "displayName": "Posecode",
   "description": "Language support for the Posecode (.posecode) kinematic motion DSL: syntax highlighting, range-of-motion diagnostics, completion, and hover.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "posecode-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "posecode-monorepo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -26,7 +26,7 @@
     },
     "editors/vscode": {
       "name": "posecode-vscode",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
@@ -7050,11 +7050,11 @@
       "extraneous": true
     },
     "packages/posecode-embed": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "posecode-parser": "0.1.0",
-        "posecode-render": "0.1.0",
+        "posecode-parser": "0.2.0",
+        "posecode-render": "0.2.0",
         "posecode-share": "0.1.0"
       },
       "devDependencies": {
@@ -7494,11 +7494,11 @@
       }
     },
     "packages/posecode-eval": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "posecode-parser": "0.1.0",
-        "posecode-render": "0.1.0",
+        "posecode-parser": "0.2.0",
+        "posecode-render": "0.2.0",
         "three": "^0.171.0"
       },
       "devDependencies": {
@@ -7506,17 +7506,17 @@
       }
     },
     "packages/posecode-language": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "posecode-parser": "0.1.0"
+        "posecode-parser": "0.2.0"
       }
     },
     "packages/posecode-lsp": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "posecode-language": "0.1.0",
+        "posecode-language": "0.2.0",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12"
       },
@@ -7959,11 +7959,11 @@
       }
     },
     "packages/posecode-mcp": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
-        "posecode-parser": "0.1.0",
+        "posecode-parser": "0.2.0",
         "posecode-share": "0.1.0",
         "zod": "^3.24.1"
       },
@@ -8409,14 +8409,20 @@
       }
     },
     "packages/posecode-parser": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.24.1"
+      },
+      "bin": {
+        "posecode-parser": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2"
       }
     },
     "packages/posecode-render": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "three": "^0.171.0"
@@ -8425,7 +8431,7 @@
         "@types/three": "^0.171.0"
       },
       "peerDependencies": {
-        "posecode-parser": "0.1.0"
+        "posecode-parser": "0.2.0"
       }
     },
     "packages/posecode-share": {
@@ -8434,7 +8440,7 @@
     },
     "playground": {
       "name": "posecode-playground",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.4",
         "@codemirror/commands": "^6.7.1",
@@ -8444,9 +8450,9 @@
         "@codemirror/view": "^6.36.1",
         "@lezer/highlight": "^1.2.1",
         "@vercel/analytics": "^2.0.1",
-        "posecode-language": "0.1.0",
-        "posecode-parser": "0.1.0",
-        "posecode-render": "0.1.0",
+        "posecode-language": "0.2.0",
+        "posecode-parser": "0.2.0",
+        "posecode-render": "0.2.0",
         "posecode-share": "0.1.0",
         "three": "^0.171.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Posecode: a kinematic motion protocol for LLMs. Describe 3D human movement as text; render it in the browser.",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "coverage": "vitest run --coverage",
     "dev": "npm run dev -w playground",
     "build": "npm run build -w playground",
+    "build:packages": "npm run build -w posecode-parser && npm run build -w posecode-share && npm run build -w posecode-render && npm run build -w posecode-embed && npm run build -w posecode-mcp",
     "prepare:xbot": "node scripts/prepare-xbot.mjs",
     "eval": "tsx packages/posecode-eval/src/cli.ts",
     "video:cut2": "remotion render video/cut2/index.tsx PosecodeCut2 docs/launch-media/posecode-cut2-builder-16x9.mp4 --public-dir video/cut2/public --codec h264 --crf 16",

--- a/packages/posecode-embed/README.md
+++ b/packages/posecode-embed/README.md
@@ -9,7 +9,7 @@ the movement as an animated 3D figure, right where a share link would have gone.
 ## Quick start (CDN, no build step)
 
 ```html
-<script src="https://unpkg.com/posecode-embed/dist/posecode-embed.js"></script>
+<script src="https://unpkg.com/posecode-embed@0.2.0/dist/posecode-embed.js"></script>
 
 <!-- 1. From a share token (what a posecode.org permalink carries) -->
 <posecode-player doc="cG9zZWNvZGUgZXhlcmNpc2Ug…"></posecode-player>
@@ -22,10 +22,10 @@ the movement as an animated 3D figure, right where a share link would have gone.
 posecode exercise "Lateral raise"
   rig humanoid
   pose start = standing
-  step "Raise" 1.4s ease-out:
+  step "Raise" 1.4s settle:
     shoulders: abduct 90
     elbows: flex 10
-  step "Lower" 1.6s ease-in:
+  step "Lower" 1.6s drive:
     shoulders: abduct 0
     elbows: flex 0
   repeat 8
@@ -34,6 +34,10 @@ posecode exercise "Lateral raise"
 
 The script auto-registers the element and boots each player when it scrolls into
 view. That's it.
+
+Pin a package version in production, as above, so a deployment always uses a
+known parser/render pair. A `src` URL can be relative or absolute; cross-origin
+movement files must be served with CORS permission.
 
 ## With a bundler
 
@@ -86,11 +90,33 @@ Boolean attributes accept `false` / `0` / `no` / `off` to turn them off, so
 
 ```js
 const player = document.querySelector("posecode-player");
-player.addEventListener("posecode:ready", () => player.viewer.pause());
-player.addEventListener("posecode:error", (e) => console.warn(e.detail.error));
+player.addEventListener("posecode:ready", (e) => {
+  console.log(e.detail.version, e.detail.languageVersion, e.detail.warnings);
+  player.viewer.pause();
+});
+player.addEventListener("posecode:error", (e) => {
+  console.warn(e.detail.code, e.detail.error, e.detail.errors);
+});
 
 player.toggle();       // play / pause
 player.viewer;         // the underlying render Viewer (null until booted)
+```
+
+The host element reflects `data-posecode-state="loading|ready|error"`, plus the
+package and language versions, for integration tests and monitoring. Existing
+listeners that only read `event.detail.error` remain compatible.
+
+CDN users can validate source without creating WebGL:
+
+```js
+const result = Posecode.validatePosecode(source);
+console.log(Posecode.version, Posecode.languageVersion, result.errors);
+```
+
+For a movement library in CI, run:
+
+```bash
+npx posecode-parser@0.2.0 validate --strict ./movements
 ```
 
 MIT-licensed, part of [Posecode](https://github.com/posecode-dev/posecode).

--- a/packages/posecode-embed/package.json
+++ b/packages/posecode-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-embed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embed a live 3D Posecode movement anywhere with one <script> tag \u2014 the <posecode-player> web component.",
   "license": "MIT",
   "type": "module",
@@ -32,8 +32,8 @@
     "three.js"
   ],
   "dependencies": {
-    "posecode-parser": "0.1.0",
-    "posecode-render": "0.1.0",
+    "posecode-parser": "0.2.0",
+    "posecode-render": "0.2.0",
     "posecode-share": "0.1.0"
   },
   "devDependencies": {

--- a/packages/posecode-embed/src/compat.ts
+++ b/packages/posecode-embed/src/compat.ts
@@ -1,0 +1,15 @@
+/** Public compatibility metadata and no-render validation for CDN consumers. */
+
+import { parse, POSECODE_VERSION } from "posecode-parser";
+import type { ParseResult } from "posecode-parser";
+
+/** Version of the posecode-embed package/bundle. */
+export const version = "0.2.0";
+
+/** Version of the Posecode language understood by this bundle. */
+export const languageVersion = POSECODE_VERSION;
+
+/** Validate source without creating a renderer or WebGL context. */
+export function validatePosecode(source: string): ParseResult {
+  return parse(source);
+}

--- a/packages/posecode-embed/src/element.ts
+++ b/packages/posecode-embed/src/element.ts
@@ -16,8 +16,10 @@
  */
 
 import { parse } from "posecode-parser";
+import type { ParseError, Warning } from "posecode-parser";
 import { encodePosecode } from "posecode-share";
 import type { Viewer } from "posecode-render";
+import { languageVersion, version } from "./compat.js";
 import { parseOptions, type PlayerOptions } from "./options.js";
 import { resolveSource } from "./source.js";
 import { PLAYER_CSS } from "./styles.js";
@@ -28,11 +30,26 @@ const PAUSE = "❚❚";
 /** Where the "open in playground" link points; overridable per element. */
 const DEFAULT_PLAYGROUND = "https://posecode.org/play";
 
+export interface PosecodeReadyDetail {
+  version: string;
+  languageVersion: string;
+  warnings: Warning[];
+}
+
+export interface PosecodeErrorDetail {
+  error: string;
+  code: "source" | "parse" | "render";
+  version: string;
+  languageVersion: string;
+  errors?: ParseError[];
+}
+
 export class PosecodePlayerElement extends HTMLElement {
   static readonly tagName = "posecode-player";
 
   #viewer: Viewer | null = null;
   #io: IntersectionObserver | null = null;
+  #connectTimer: number | null = null;
   #booted = false;
   #root: ShadowRoot;
   #canvas!: HTMLCanvasElement;
@@ -46,9 +63,25 @@ export class PosecodePlayerElement extends HTMLElement {
   }
 
   connectedCallback(): void {
-    // Capture inline text BEFORE we replace the light DOM with shadow markup.
-    this.#source = this.textContent ?? "";
+    this.setAttribute("data-posecode-state", "loading");
+    this.setAttribute("data-posecode-version", version);
+    this.setAttribute("data-posecode-language-version", languageVersion);
     this.#renderChrome();
+    // A synchronous CDN script can define this element before the HTML parser
+    // has appended its inline text children. Wait one task so
+    // `<script ...></script><posecode-player>...</posecode-player>` works in a
+    // plain document, while doc/src attributes still boot immediately after.
+    this.#connectTimer = window.setTimeout(() => {
+      this.#connectTimer = null;
+      this.#startConnected();
+    }, 0);
+  }
+
+  #startConnected(): void {
+    if (!this.isConnected || this.#booted) return;
+    this.#source = this.textContent ?? "";
+    const link = this.#root.querySelector("a.link") as HTMLAnchorElement | null;
+    if (link) link.href = this.#playgroundUrl();
     // Boot immediately UNLESS the element is measurably off-screen, in which
     // case defer the heavy renderer until it scrolls into view. The bias is
     // toward booting: an embed must never stay blank because we couldn't
@@ -75,6 +108,8 @@ export class PosecodePlayerElement extends HTMLElement {
   }
 
   disconnectedCallback(): void {
+    if (this.#connectTimer !== null) window.clearTimeout(this.#connectTimer);
+    this.#connectTimer = null;
     this.#io?.disconnect();
     this.#io = null;
     this.#viewer?.dispose();
@@ -160,14 +195,18 @@ export class PosecodePlayerElement extends HTMLElement {
       src: this.getAttribute("src"),
       text: this.#source,
     });
-    if (!resolved.ok) return this.#showMessage(resolved.error, true);
+    if (!resolved.ok) return this.#showError(resolved.error, "source");
 
     // Keep the resolved source so the "Edit" link matches what's rendered.
     this.#source = resolved.source;
-    const { ir, errors } = parse(resolved.source);
+    const { ir, errors, warnings } = parse(resolved.source);
     if (!ir || errors.length > 0) {
       const detail = errors[0] ? `${errors[0].message} (line ${errors[0].line})` : "";
-      return this.#showMessage(`Couldn't parse this movement. ${detail}`.trim(), true);
+      return this.#showError(
+        `Couldn't parse this movement. ${detail}`.trim(),
+        "parse",
+        errors,
+      );
     }
 
     const opts = this.#options();
@@ -176,43 +215,55 @@ export class PosecodePlayerElement extends HTMLElement {
       matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     // Lazy-import the heavy renderer only once we actually have work to show.
-    const { createViewer } = await import("posecode-render");
-    const viewer = createViewer(this.#canvas, {
-      autoRotate: opts.autoRotate && !reduceMotion,
-      ...(opts.characterUrl ? { characterUrl: opts.characterUrl } : {}),
-    });
-    this.#viewer = viewer;
-    viewer.onPhase(({ phaseName }) => {
-      this.#phaseEl.textContent = phaseName === "reset" ? "" : phaseName;
-    });
-    viewer.load(ir);
-    viewer.setLoop(opts.loop);
-    viewer.setSpeed(opts.speed);
+    try {
+      const { createViewer } = await import("posecode-render");
+      const viewer = createViewer(this.#canvas, {
+        autoRotate: opts.autoRotate && !reduceMotion,
+        ...(opts.characterUrl ? { characterUrl: opts.characterUrl } : {}),
+      });
+      this.#viewer = viewer;
+      viewer.onPhase(({ phaseName }) => {
+        this.#phaseEl.textContent = phaseName === "reset" ? "" : phaseName;
+      });
+      viewer.load(ir);
+      viewer.setLoop(opts.loop);
+      viewer.setSpeed(opts.speed);
 
-    const shouldPlay = opts.autoplay && !reduceMotion;
-    if (shouldPlay) viewer.play();
-    this.#reflectPlaying(shouldPlay);
+      const shouldPlay = opts.autoplay && !reduceMotion;
+      if (shouldPlay) viewer.play();
+      this.#reflectPlaying(shouldPlay);
 
-    // Update the Edit link now that we know the real source.
-    const link = this.#root.querySelector("a.link") as HTMLAnchorElement | null;
-    if (link) link.href = this.#playgroundUrl();
+      // Update the Edit link now that we know the real source.
+      const link = this.#root.querySelector("a.link") as HTMLAnchorElement | null;
+      if (link) link.href = this.#playgroundUrl();
 
-    this.dispatchEvent(new CustomEvent("posecode:ready", { bubbles: true }));
+      this.setAttribute("data-posecode-state", "ready");
+      const detail: PosecodeReadyDetail = { version, languageVersion, warnings };
+      this.dispatchEvent(new CustomEvent("posecode:ready", { bubbles: true, detail }));
+    } catch {
+      this.#viewer?.dispose();
+      this.#viewer = null;
+      this.#showError("Couldn't start the Posecode renderer.", "render");
+    }
   }
 
   #reflectPlaying(playing: boolean): void {
     this.#playBtn.textContent = playing ? PAUSE : PLAY;
   }
 
-  #showMessage(text: string, isError: boolean): void {
+  #showError(text: string, code: PosecodeErrorDetail["code"], errors?: ParseError[]): void {
     const msg = document.createElement("div");
-    msg.className = isError ? "msg error" : "msg";
+    msg.className = "msg error";
     msg.textContent = text;
     this.#root.append(msg);
-    if (isError) {
-      this.dispatchEvent(
-        new CustomEvent("posecode:error", { bubbles: true, detail: { error: text } }),
-      );
-    }
+    this.setAttribute("data-posecode-state", "error");
+    const detail: PosecodeErrorDetail = {
+      error: text,
+      code,
+      version,
+      languageVersion,
+      ...(errors ? { errors } : {}),
+    };
+    this.dispatchEvent(new CustomEvent("posecode:error", { bubbles: true, detail }));
   }
 }

--- a/packages/posecode-embed/src/index.ts
+++ b/packages/posecode-embed/src/index.ts
@@ -18,8 +18,8 @@ export { parseOptions, DEFAULT_OPTIONS } from "./options.js";
 export type { PlayerOptions } from "./options.js";
 export { resolveSource } from "./source.js";
 export type { SourceInput, Resolved } from "./source.js";
-
-export const version = "0.1.0";
+export { version, languageVersion, validatePosecode } from "./compat.js";
+export type { PosecodeReadyDetail, PosecodeErrorDetail } from "./element.js";
 
 /**
  * Register the `<posecode-player>` custom element. Safe to call more than once

--- a/packages/posecode-embed/test/compat.test.ts
+++ b/packages/posecode-embed/test/compat.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { languageVersion, validatePosecode, version } from "../src/compat.js";
+
+const SPORTS_MOVE = `posecode exercise "Crossover"
+  rig humanoid
+  pose start = standing
+  step "Load" 0.4s settle:
+    knees: flex 68
+    ground-lock: feet
+  step "Cross" 0.22s drive:
+    pelvis: rotate-out 14
+    travel: -0.18 0
+    ground-lock: feet
+  repeat 2
+`;
+
+describe("embed compatibility contract", () => {
+  it("validates current timing-mode documents without starting WebGL", () => {
+    const result = validatePosecode(SPORTS_MOVE);
+    expect(result.errors).toEqual([]);
+    expect(result.ir?.phases.map((phase) => phase.easing)).toEqual(["settle", "drive"]);
+  });
+
+  it("keeps exported package metadata aligned with the package manifest", () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+    ) as { version: string };
+    expect(version).toBe(pkg.version);
+    expect(languageVersion).toBe("0.2");
+  });
+});

--- a/packages/posecode-eval/package.json
+++ b/packages/posecode-eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-eval",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Fidelity eval harness for Posecode: headless kinematic probing + geometric invariant scoring.",
   "license": "MIT",
   "type": "module",
@@ -10,8 +10,8 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "posecode-parser": "0.1.0",
-    "posecode-render": "0.1.0",
+    "posecode-parser": "0.2.0",
+    "posecode-render": "0.2.0",
     "three": "^0.171.0"
   },
   "devDependencies": {

--- a/packages/posecode-language/package.json
+++ b/packages/posecode-language/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-language",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Editor language service for .posecode: diagnostics, completions, and hovers built on posecode-parser. Powers both the playground editor and the LSP.",
   "license": "MIT",
   "type": "module",
@@ -10,6 +10,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "posecode-parser": "0.1.0"
+    "posecode-parser": "0.2.0"
   }
 }

--- a/packages/posecode-language/src/vocab.ts
+++ b/packages/posecode-language/src/vocab.ts
@@ -50,7 +50,7 @@ export const KEYWORD_DOCS: Record<string, string> = {
   snap: "Timing mode: fast, near-immediate arrival — an accent.",
   linear: "Timing mode: constant velocity — intentionally mechanical.",
   repeat: "How many times the movement loops.",
-  "ground-lock": "Pins grouped or per-side effectors to the floor for this phase: `ground-lock: feet`, `ground-lock: foot_right`. Planted feet auto-level flat unless the ankle is plantarflexed (tiptoe).",
+  "ground-lock": "Pins grouped or per-side effectors to the floor: `feet`, `foot_left` (also written `left foot`), `hands`, or `forearms`. Planted feet auto-level unless the ankle is intentionally plantarflexed.",
   reach:
     "Drives an effector to a target via ROM-constrained IK: `reach: hand_left ankle_left`, `reach: hands floor`.",
   pin: "Moves the body so an effector sits on an anchor: `pin: hands bar` (hang, pull up, step up, dip).",

--- a/packages/posecode-language/test/language.test.ts
+++ b/packages/posecode-language/test/language.test.ts
@@ -75,7 +75,7 @@ describe("getCompletions", () => {
 
   it("suggests effectors after `ground-lock: `", () => {
     expect(onLine("    ground-lock: ", 17)).toEqual(
-      expect.arrayContaining(["hands", "feet", "hand_left", "foot_right"]),
+      expect.arrayContaining(["hands", "feet", "hand_left", "hand_right", "foot_left", "foot_right"]),
     );
   });
 

--- a/packages/posecode-lsp/package.json
+++ b/packages/posecode-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-lsp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Language Server Protocol implementation for the Posecode (.posecode) DSL: diagnostics, completion, and hover, powered by posecode-language.",
   "license": "MIT",
   "type": "module",
@@ -15,7 +15,7 @@
     "start": "tsx src/server.ts"
   },
   "dependencies": {
-    "posecode-language": "0.1.0",
+    "posecode-language": "0.2.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/packages/posecode-mcp/package.json
+++ b/packages/posecode-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Model Context Protocol server for Posecode: let any LLM agent validate, ROM-check, and get a render link for a .posecode movement, natively.",
   "mcpName": "io.github.posecode-dev/posecode-mcp",
   "license": "MIT",
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "posecode-parser": "0.1.0",
+    "posecode-parser": "0.2.0",
     "posecode-share": "0.1.0",
     "zod": "^3.24.1"
   },

--- a/packages/posecode-mcp/server.json
+++ b/packages/posecode-mcp/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/posecode-dev/posecode",
     "source": "github"
   },
-  "version": "0.1.1",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "posecode-mcp",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/packages/posecode-mcp/src/guide.ts
+++ b/packages/posecode-mcp/src/guide.ts
@@ -35,9 +35,9 @@ Output ONLY a \`.posecode\` document in a code block, no prose.
 posecode <kind> "<Name>"          # kind = exercise | stretch | posture
   rig humanoid
   pose start = <pose>          # neutral | standing | plank
-  step "<Phase>" <Ns> <easing>:  # easing = linear | ease-in | ease-out | ease-in-out
+  step "<Phase>" <Ns> <mode>:  # mode = flow | settle | drive | snap | linear
     <joint>: <action> <degrees>
-    ground-lock: <effectors>   # hands and/or feet pinned to the floor
+    ground-lock: <effectors>   # feet/hands/forearms, or one side: foot_left / left foot
     cue "<short coaching cue>"
   repeat <count>
 \`\`\`

--- a/packages/posecode-mcp/src/server.ts
+++ b/packages/posecode-mcp/src/server.ts
@@ -22,7 +22,7 @@ export interface PosecodeServerOptions {
 
 export function createPosecodeServer(opts: PosecodeServerOptions = {}): McpServer {
   const baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
-  const server = new McpServer({ name: "posecode", version: "0.1.0" });
+  const server = new McpServer({ name: "posecode", version: "0.2.0" });
 
   const sourceSchema = {
     source: z.string().describe("The full .posecode document text"),

--- a/packages/posecode-parser/README.md
+++ b/packages/posecode-parser/README.md
@@ -23,7 +23,7 @@ const { ir, warnings, errors } = parse(`
     rig humanoid
     pose start = standing
 
-    step "Descend" 1.6s ease-in-out:
+    step "Descend" 1.6s settle:
       hips: flex 80
       knees: flex 95
       ground-lock: feet
@@ -35,6 +35,25 @@ if (errors.length === 0 && ir) {
   // Pass `ir` to posecode-render to animate it, or inspect it directly.
 }
 ```
+
+## Validate a movement library
+
+Version 0.2 includes a zero-config validator for local files and directories:
+
+```bash
+npx posecode-parser@0.2.0 validate ./movements
+npx posecode-parser@0.2.0 validate --strict ./movements
+```
+
+The command recurses through directories, prints file-and-line diagnostics, and
+exits non-zero for parse errors. `--strict` also fails on ROM-clamp warnings;
+`--json` emits machine-readable results for CI.
+
+## Timing modes
+
+Canonical modes are `flow`, `settle`, `drive`, `snap`, and `linear`. The v0.1
+aliases `ease-in`, `ease-out`, and `ease-in-out` remain accepted so existing
+movement files keep working.
 
 `parse()` never throws: malformed or out-of-range documents come back as
 structured `errors`/`warnings` instead. Every joint angle in `ir` is hard-clamped

--- a/packages/posecode-parser/package.json
+++ b/packages/posecode-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-parser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Parse the .posecode kinematic motion DSL into a validated, ROM-clamped intermediate representation.",
   "license": "MIT",
   "type": "module",
@@ -9,8 +9,14 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "bin": {
+    "posecode-parser": "dist/cli.js"
+  },
   "dependencies": {
     "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2"
   },
   "repository": {
     "type": "git",

--- a/packages/posecode-parser/src/cli.ts
+++ b/packages/posecode-parser/src/cli.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Small, dependency-free validator for third-party movement libraries.
+ *
+ * Usage:
+ *   posecode-parser validate movement.posecode ./movement-directory
+ *   posecode-parser validate --strict --json ./movement-directory
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parse } from "./index.js";
+import type { ParseError, Warning } from "./types.js";
+
+export interface FileValidation {
+  file: string;
+  errors: ParseError[];
+  warnings: Warning[];
+}
+
+export interface ValidationSummary {
+  files: FileValidation[];
+  fileCount: number;
+  errorCount: number;
+  warningCount: number;
+}
+
+export function validatePaths(inputs: string[]): ValidationSummary {
+  const paths = [...new Set(inputs.flatMap(collectPosecodeFiles))].sort();
+  const files = paths.map((file): FileValidation => {
+    const source = readFileSync(file, "utf8");
+    const { errors, warnings } = parse(source);
+    return { file, errors, warnings };
+  });
+
+  return {
+    files,
+    fileCount: files.length,
+    errorCount: files.reduce((total, file) => total + file.errors.length, 0),
+    warningCount: files.reduce((total, file) => total + file.warnings.length, 0),
+  };
+}
+
+function collectPosecodeFiles(input: string): string[] {
+  const path = resolve(input);
+  const stat = statSync(path);
+  if (stat.isFile()) return extname(path) === ".posecode" ? [path] : [];
+  if (!stat.isDirectory()) return [];
+
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const child = resolve(path, entry.name);
+    if (entry.isDirectory()) return collectPosecodeFiles(child);
+    return entry.isFile() && extname(entry.name) === ".posecode" ? [child] : [];
+  });
+}
+
+export function renderValidation(summary: ValidationSummary): string {
+  const lines: string[] = [];
+  for (const file of summary.files) {
+    for (const error of file.errors) {
+      lines.push(`${file.file}:${error.line}: error: ${error.message}`);
+    }
+    for (const warning of file.warnings) {
+      lines.push(
+        `${file.file}:${warning.line}: warning: ${warning.joint} ${warning.action} ` +
+          `${warning.requested}° was clamped to ${warning.clamped}°`,
+      );
+    }
+  }
+  lines.push(
+    `Validated ${summary.fileCount} .posecode file(s): ` +
+      `${summary.errorCount} error(s), ${summary.warningCount} warning(s).`,
+  );
+  return lines.join("\n");
+}
+
+export function main(argv: string[]): number {
+  const args = argv[0] === "validate" ? argv.slice(1) : argv;
+  const json = args.includes("--json");
+  const strict = args.includes("--strict");
+  const inputs = args.filter((arg) => !arg.startsWith("--"));
+
+  if (inputs.length === 0) {
+    console.error("Usage: posecode-parser validate [--strict] [--json] <file-or-directory> [...]");
+    return 2;
+  }
+
+  try {
+    const summary = validatePaths(inputs);
+    if (summary.fileCount === 0) {
+      console.error("No .posecode files found.");
+      return 2;
+    }
+    console.log(json ? JSON.stringify(summary, null, 2) : renderValidation(summary));
+    return summary.errorCount > 0 || (strict && summary.warningCount > 0) ? 1 : 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/packages/posecode-parser/src/joints.ts
+++ b/packages/posecode-parser/src/joints.ts
@@ -143,7 +143,6 @@ const GROUND_LOCK_EFFECTOR_SET = new Set<string>(GROUND_LOCK_EFFECTOR_NAMES);
 export function isGroundLockEffector(name: string): boolean {
   return GROUND_LOCK_EFFECTOR_SET.has(name);
 }
-
 const EFFECTOR_SIDE_SET = new Set<string>(EFFECTOR_SIDES);
 
 /**

--- a/packages/posecode-parser/src/parser.ts
+++ b/packages/posecode-parser/src/parser.ts
@@ -9,6 +9,9 @@
 import { tokenize, TokenizeError, type Line, type Token } from "./tokenizer.js";
 import type { ParseError } from "./types.js";
 import { normalizeMode, MODES } from "./schema.js";
+import { GROUND_LOCK_EFFECTOR_NAMES } from "./joints.js";
+
+const GROUND_LOCK_EFFECTORS = new Set<string>(GROUND_LOCK_EFFECTOR_NAMES);
 
 export interface AstJointTarget {
   joint: string;
@@ -110,9 +113,17 @@ export function parseToAst(source: string): ParseAstResult {
   };
 
   let current: AstStep | null = null;
+  let invalidStepIndent: number | null = null;
 
   for (let i = 1; i < lines.length; i++) {
     const ln = lines[i]!;
+    // A malformed step header already explains why the phase cannot be parsed.
+    // Ignore its indented children so authors get one actionable diagnostic
+    // instead of a cascade of misleading "outside of a step" errors.
+    if (invalidStepIndent !== null) {
+      if (ln.indent > invalidStepIndent) continue;
+      invalidStepIndent = null;
+    }
     const head = word(ln.tokens[0]);
     const t = ln.tokens;
 
@@ -175,6 +186,7 @@ export function parseToAst(source: string): ParseAstResult {
                 : 'expected `step "<name>" <duration> <mode>:`',
           });
           current = null;
+          invalidStepIndent = ln.indent;
           break;
         }
         current = {
@@ -219,10 +231,32 @@ function parseStepChild(ln: Line, current: AstStep | null): ParseError | null {
 
   if (head === "ground-lock") {
     if (!current) return { line: ln.line, message: "`ground-lock` outside of a step" };
-    const effectors = t
-      .slice(1)
-      .filter((tok) => tok.type === "word")
-      .map((tok) => tok.value);
+    if (t[1]?.type !== "colon") {
+      return { line: ln.line, message: "expected `ground-lock: <effectors>`" };
+    }
+    const words = t.slice(2).filter((tok) => tok.type === "word").map((tok) => tok.value);
+    const effectors: string[] = [];
+    for (let i = 0; i < words.length; i++) {
+      const value = words[i]!;
+      if (value === "and") continue;
+      const next = words[i + 1];
+      if ((value === "left" || value === "right") && next) {
+        const base = next === "hand" ? "hand" : next === "foot" ? "foot" :
+          next === "forearm" || next === "elbow" ? "elbow" : null;
+        if (base) {
+          effectors.push(`${base}_${value}`);
+          i++;
+          continue;
+        }
+      }
+      if (!GROUND_LOCK_EFFECTORS.has(value)) {
+        return { line: ln.line, message: `unknown ground-lock effector: "${value}"` };
+      }
+      effectors.push(value);
+    }
+    if (effectors.length === 0) {
+      return { line: ln.line, message: "`ground-lock` requires at least one effector" };
+    }
     current.groundLock = effectors;
     current.groundLockLine = ln.line;
     return null;

--- a/packages/posecode-parser/src/types.ts
+++ b/packages/posecode-parser/src/types.ts
@@ -7,7 +7,8 @@
  * convention documented in `joints.ts` and `spec/SPEC.md`.
  */
 
-export const POSECODE_VERSION = "0.1";
+/** Version of the parsed Posecode language/IR contract. */
+export const POSECODE_VERSION = "0.2";
 
 export type Axis = "x" | "y" | "z";
 

--- a/packages/posecode-parser/test/cli.test.ts
+++ b/packages/posecode-parser/test/cli.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { renderValidation, validatePaths } from "../src/cli.js";
+
+const SPORTS_MOVE = `posecode exercise "Jump shot"
+  rig humanoid
+  pose start = standing
+  step "Gather" 0.4s settle:
+    knees: flex 70
+    ground-lock: feet
+  step "Explode" 0.3s drive:
+    knees: flex 10
+    ankles: plantarflex 26
+    travel: 0 0.12
+    ground-lock: feet
+  step "Release" 0.2s snap:
+    shoulders: flex 160
+    wrists: flex 34
+  repeat 1
+`;
+
+describe("posecode validator", () => {
+  it("recursively validates third-party movement libraries using timing modes", () => {
+    const root = mkdtempSync(join(tmpdir(), "posecode-validator-"));
+    const nested = join(root, "basketball");
+    mkdirSync(nested);
+    writeFileSync(join(nested, "jump-shot.posecode"), SPORTS_MOVE);
+
+    const summary = validatePaths([root]);
+
+    expect(summary).toMatchObject({ fileCount: 1, errorCount: 0, warningCount: 0 });
+  });
+
+  it("prints file and line diagnostics for invalid timing modes", () => {
+    const root = mkdtempSync(join(tmpdir(), "posecode-validator-"));
+    const file = join(root, "broken.posecode");
+    writeFileSync(file, SPORTS_MOVE.replace("0.3s drive", "0.3s turbo"));
+
+    const summary = validatePaths([file]);
+    const output = renderValidation(summary);
+
+    expect(summary.errorCount).toBe(1);
+    expect(output).toContain(`${file}:7: error:`);
+    expect(output).toContain('unknown timing mode "turbo"');
+  });
+});

--- a/packages/posecode-render/package.json
+++ b/packages/posecode-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-render",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Render a Posecode IR as an animated 3D human figure (skinned character or procedural mannequin) with Three.js.",
   "license": "MIT",
   "type": "module",
@@ -13,7 +13,7 @@
     "three": "^0.171.0"
   },
   "peerDependencies": {
-    "posecode-parser": "0.1.0"
+    "posecode-parser": "0.2.0"
   },
   "devDependencies": {
     "@types/three": "^0.171.0"

--- a/packages/posecode-render/src/index.ts
+++ b/packages/posecode-render/src/index.ts
@@ -1105,8 +1105,8 @@ function floorHandSidesOf(
 ): Set<"left" | "right"> {
   const sides = new Set<"left" | "right">();
   const add = (effector: string): void => {
-    if (effector.endsWith("_left") || effector === "hands") sides.add("left");
-    if (effector.endsWith("_right") || effector === "hands") sides.add("right");
+    if (effector === "hands" || effector === "hand_left") sides.add("left");
+    if (effector === "hands" || effector === "hand_right") sides.add("right");
   };
   for (const r of reaches) if (r.target === "floor") add(r.effector);
   for (const p of pins) if (p.anchor === "floor") add(p.effector);

--- a/packages/posecode-render/test/render.test.ts
+++ b/packages/posecode-render/test/render.test.ts
@@ -446,6 +446,26 @@ describe("ground-lock (shared solver)", () => {
     expect(leftSole).toBeGreaterThan(0.1);
   });
 
+  it("normalizes and plants a human-readable single-foot lock", () => {
+    const source = [
+      'posecode exercise "Layup"',
+      "  rig humanoid",
+      "  pose start = standing",
+      '  step "Plant" 1s settle:',
+      "    knee_left: flex 86",
+      "    hip_left: flex 62",
+      "    ground-lock: left foot",
+    ].join("\n");
+    const { ir, errors } = parse(source);
+    expect(errors).toEqual([]);
+    expect(ir?.phases[0]?.groundLock).toEqual(["foot_left"]);
+
+    const m = posedRaw(source);
+    applyGroundLock(m, ir!.phases[0]!.groundLock);
+    const soleY = new THREE.Box3().setFromObject(m.bones.get("ankle_left")!).min.y;
+    expect(Math.abs(soleY)).toBeLessThan(0.01);
+  });
+
   it("is a no-op when no effectors are ground-locked", () => {
     const m = posedRaw(
       [

--- a/playground/embed-demo.html
+++ b/playground/embed-demo.html
@@ -35,11 +35,11 @@
 posecode exercise "Lateral raise"
   rig humanoid
   pose start = standing
-  step "Raise" 1.4s ease-out:
+  step "Raise" 1.4s settle:
     shoulders: abduct 90
     elbows: flex 10
     cue "Lift out to shoulder height, soft elbows"
-  step "Lower" 1.6s ease-in:
+  step "Lower" 1.6s drive:
     shoulders: abduct 0
     elbows: flex 0
   repeat 8
@@ -55,13 +55,13 @@ posecode exercise "Lateral raise"
         const deadlift = `posecode exercise "Deadlift"
   rig humanoid
   pose start = standing
-  step "Lower" 1.8s ease-in-out:
+  step "Lower" 1.8s settle:
     pelvis: hinge 75
     knees: flex 25
     shoulders: extend 60
     ground-lock: feet
     cue "Push the hips back and hinge with a flat back"
-  step "Lift" 1.4s ease-out:
+  step "Lift" 1.4s drive:
     pelvis: hinge 0
     knees: flex 0
     shoulders: extend 0

--- a/playground/index.html
+++ b/playground/index.html
@@ -183,7 +183,7 @@
         <pre class="code-chip" aria-hidden="true"><span class="t-kw">posecode</span> <span class="t-kind">exercise</span> <span class="t-str">"Jumping jacks"</span>
   <span class="t-kw">pose</span> start <span class="t-punct">=</span> <span class="t-atom">standing</span>
 
-  <span class="t-kw">step</span> <span class="t-str">"Out"</span> <span class="t-num">0.5s</span> <span class="t-atom">ease-out</span><span class="t-punct">:</span>
+  <span class="t-kw">step</span> <span class="t-str">"Out"</span> <span class="t-num">0.5s</span> <span class="t-atom">settle</span><span class="t-punct">:</span>
     <span class="t-joint">shoulders</span><span class="t-punct">:</span> <span class="t-act">abduct</span> <span class="t-num">160</span>
     <span class="t-joint">hips</span><span class="t-punct">:</span> <span class="t-act">abduct</span> <span class="t-num">30</span>
     <span class="t-kw">ground-lock</span><span class="t-punct">:</span> <span class="t-atom">feet</span></pre>
@@ -339,7 +339,7 @@
         Consult a qualified professional for physiotherapy or exercise prescription.
       </p>
       <p class="footer-legal">
-        MIT-licensed open core · v0.1 &nbsp;·&nbsp;
+        MIT-licensed open core · v0.2 &nbsp;·&nbsp;
         <a href="./moves/">Movement library</a> &nbsp;·&nbsp;
         <a href="./spec.html">Language spec</a> &nbsp;·&nbsp;
         <a href="./llm-guide.html">LLM guide</a> &nbsp;·&nbsp;

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-playground",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -17,9 +17,9 @@
     "@codemirror/view": "^6.36.1",
     "@lezer/highlight": "^1.2.1",
     "@vercel/analytics": "^2.0.1",
-    "posecode-language": "0.1.0",
-    "posecode-parser": "0.1.0",
-    "posecode-render": "0.1.0",
+    "posecode-language": "0.2.0",
+    "posecode-parser": "0.2.0",
+    "posecode-render": "0.2.0",
     "posecode-share": "0.1.0",
     "three": "^0.171.0"
   },

--- a/playground/public/llm-guide.html
+++ b/playground/public/llm-guide.html
@@ -130,10 +130,10 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   prop &lt;type&gt;                  # optional: chair | wall | bar | box | dip-bars (repeatable)
   pose start = &lt;pose&gt;          # neutral | standing | plank | supine | prone | seated
-  step &quot;&lt;Phase name&gt;&quot; &lt;Ns&gt; &lt;easing&gt;:   # easing = linear | ease-in | ease-out | ease-in-out
+  step &quot;&lt;Phase name&gt;&quot; &lt;Ns&gt; &lt;mode&gt;:     # mode = flow | settle | drive | snap | linear
     &lt;joint&gt;: &lt;action&gt; &lt;degrees&gt;
     reach: &lt;effector&gt; &lt;target&gt; # optional: drive a hand/foot to a target via IK
-    ground-lock: &lt;effectors&gt;   # groups (hands/forearms/feet) or per-side aliases such as foot_right
+    ground-lock: &lt;effectors&gt;   # groups, foot_left/foot_right, or natural left foot/right foot
     turn: &lt;degrees&gt;            # optional: face this yaw by phase end (standing only)
     travel: &lt;x&gt; &lt;z&gt;            # optional: move to this x z (metres) by phase end
     cue &quot;&lt;short coaching cue&gt;&quot;
@@ -152,19 +152,26 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <ol><li>Add a one-line <code>cue</code> per phase. Use <code>ground-lock</code> for whatever touches the</li></ol>
 <p>floor (feet when standing; hands and feet in a plank).</p>
 <ol><li><code>repeat</code> the rep count.</li></ol>
+<h2>Timing modes</h2>
+<ul><li><code>flow</code>: carry momentum through an interior pose; use for continuous dance,</li></ul>
+<p>locomotion, and multi-part sports motion.</p>
+<ul><li><code>settle</code>: decelerate into a real rest; use at a squat bottom, landing, hold,</li></ul>
+<p>or final pose.</p>
+<ul><li><code>drive</code>: accelerate from rest; use for a jump, push, lift, or recoil.</li><li><code>snap</code>: arrive quickly and stop sharply; use for a strike or release.</li><li><code>linear</code>: constant timing; best for deliberate holds or mechanical motion.</li></ul>
+<p>The older names <code>ease-in</code>, <code>ease-out</code>, and <code>ease-in-out</code> still parse for compatibility, but do not author new documents with them.</p>
 <h2>Example</h2>
 <pre class="code-block" data-lang="posecode"><code>posecode exercise &quot;Body-weight squat&quot;
   rig humanoid
   pose start = standing
 
-  step &quot;Descend&quot; 1.6s ease-in-out:
+  step &quot;Descend&quot; 1.6s settle:
     hips: flex 80
     knees: flex 95
     ankles: dorsiflex 14
     ground-lock: feet
     cue &quot;Sit the hips back, chest proud, knees track over the toes&quot;
 
-  step &quot;Drive up&quot; 1.2s ease-out:
+  step &quot;Drive up&quot; 1.2s drive:
     hips: flex 0
     knees: flex 0
     ankles: dorsiflex 0
@@ -178,14 +185,14 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Lower&quot; 1.8s ease-in-out:
+  step &quot;Lower&quot; 1.8s settle:
     pelvis: hinge 95
     knees: flex 25
     shoulders: flex 90
     ground-lock: feet
     cue &quot;Hips back, flat back: let the arms hang to the bar&quot;
 
-  step &quot;Lift&quot; 1.4s ease-out:
+  step &quot;Lift&quot; 1.4s drive:
     pelvis: hinge 0
     knees: flex 0
     shoulders: flex 0
@@ -196,7 +203,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <h2>Reaching, props, lying poses &amp; hands</h2>
 <ul><li><strong>Reach a target</strong>: <code>reach: &lt;effector&gt; &lt;target&gt;</code> drives a hand or foot to a</li></ul>
 <p>world point via IK. Effectors: <code>hand_left hand_right foot_left foot_right</code>, or <code>hands</code> / <code>feet</code> for both sides at once. Targets: a body landmark bone (<code>ankle_left</code>, <code>knee_right</code>…), <code>floor</code>, or a prop anchor (<code>bar</code>, <code>seat</code>, <code>wall</code>). The solve is ROM-constrained: the arm/leg can never exceed the safe joint limits chasing a target, so an out-of-reach target just yields the closest healthy pose. Author the gross pose (e.g. a <code>pelvis: hinge</code>), then let <code>reach</code> finish the hand placement. Example, touch your toes:</p>
-<p>``<code>posecode step &quot;Fold&quot; 2.5s ease-in-out: pelvis: hinge 95 knees: flex 12 reach: hand_left ankle_left reach: hand_right ankle_right ground-lock: feet cue &quot;Hinge and reach toward the ankles&quot; </code>``</p>
+<p>``<code>posecode step &quot;Fold&quot; 2.5s settle: pelvis: hinge 95 knees: flex 12 reach: hand_left ankle_left reach: hand_right ankle_right ground-lock: feet cue &quot;Hinge and reach toward the ankles&quot; </code>``</p>
 <ul><li><strong>Props</strong>: <code>prop chair | wall | bar | box | dip-bars</code> (top level). The chair</li></ul>
 <p>sits behind the figure (sit-to-stand, box squat), the wall behind that (wall sit), the bar overhead, the box in front (step-ups), and the dip bars either side at hip-press height (<code>pin: hands bars</code> + elbow flex = triceps dips).</p>
 <ul><li><strong>Pins</strong>: <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> moves the whole BODY so the effector sits</li></ul>
@@ -213,8 +220,8 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <p>singular joint (<code>knee_right: flex 95</code>) and skip <code>ground-lock</code> so the standing leg stays planted.</p>
 <ul><li><strong>Desk / posture</strong>: slow <code>stretch</code> documents with <code>ground-lock: feet</code>;</li></ul>
 <p>contrast a &quot;collapsed&quot; phase with a &quot;tall&quot; reset.</p>
-<ul><li><strong>Sports / martial arts</strong>: short, snappy phases (0.3–0.6s) with <code>ease-out</code></li></ul>
-<p>on the strike; chamber → extend → re-chamber → return.</p>
+<ul><li><strong>Sports / martial arts</strong>: short phases (0.2–0.6s); use <code>flow</code> through a</li></ul>
+<p>gather/chamber, <code>drive</code> for takeoff, and <code>snap</code> on the strike or release.</p>
 <h3>Dance / choreography</h3>
 <p>Posecode shines for <strong>showing the movement in your head</strong>. Build a phrase as a sequence of phases, one per count or musical beat, and let later phases inherit unset joints:</p>
 <ul><li><strong>Turnout:</strong> <code>hips: rotate-out 25–30</code>.</li><li><strong>Port de bras (arm positions):</strong> first <code>shoulders: flex 30, elbows: flex 35</code>;</li></ul>

--- a/playground/public/moves/box-step.html
+++ b/playground/public/moves/box-step.html
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Box step","description":"How to do the box step (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Step forward-right","text":"Step the right foot forward and out to the corner"},{"@type":"HowToStep","name":"Close the feet","text":"Bring the left foot to meet it, standing tall on the corner"},{"@type":"HowToStep","name":"Step back-left","text":"Step the left foot back to the start on the diagonal"},{"@type":"HowToStep","name":"Close home","text":"Close the feet together, back home and ready to repeat"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Box step","description":"How to do the box step (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Right foot forward","text":"Step forward onto the right foot with an easy contralateral arm swing"},{"@type":"HowToStep","name":"Left foot side","text":"Transfer left to the side, keeping the torso lifted"},{"@type":"HowToStep","name":"Right foot back","text":"Step back onto the right foot to trace the third side of the box"},{"@type":"HowToStep","name":"Left foot closes home","text":"Close the left foot and settle over both feet, completing the square"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -135,20 +135,20 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Step forward-right<span class="step-dur">0.9s · flow</span></span>
-          <span class="step-cue">Step the right foot forward and out to the corner</span>
+          <span class="step-name">Right foot forward<span class="step-dur">0.9s · flow</span></span>
+          <span class="step-cue">Step forward onto the right foot with an easy contralateral arm swing</span>
         </li>
 <li>
-          <span class="step-name">Close the feet<span class="step-dur">0.7s · flow</span></span>
-          <span class="step-cue">Bring the left foot to meet it, standing tall on the corner</span>
+          <span class="step-name">Left foot side<span class="step-dur">0.85s · flow</span></span>
+          <span class="step-cue">Transfer left to the side, keeping the torso lifted</span>
         </li>
 <li>
-          <span class="step-name">Step back-left<span class="step-dur">0.9s · flow</span></span>
-          <span class="step-cue">Step the left foot back to the start on the diagonal</span>
+          <span class="step-name">Right foot back<span class="step-dur">0.9s · flow</span></span>
+          <span class="step-cue">Step back onto the right foot to trace the third side of the box</span>
         </li>
 <li>
-          <span class="step-name">Close home<span class="step-dur">0.7s · settle</span></span>
-          <span class="step-cue">Close the feet together, back home and ready to repeat</span>
+          <span class="step-name">Left foot closes home<span class="step-dur">0.85s · settle</span></span>
+          <span class="step-cue">Close the left foot and settle over both feet, completing the square</span>
         </li>
       </ol>
 
@@ -159,43 +159,50 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Step forward-right&quot; 0.9s flow:
-    hip_right: flex 35
-    knee_right: flex 40
-    ankle_right: plantarflex 40
-    shoulder_left: flex 25
-    shoulder_right: extend 15
-    travel: -0.35 0.35
+  step &quot;Right foot forward&quot; 0.9s flow:
+    hip_right: flex 30
+    knee_right: flex 32
+    ankle_right: plantarflex 24
+    shoulder_left: flex 22
+    shoulder_right: extend 12
+    travel: 0 0.32
     pin: foot_left floor
-    cue &quot;Step the right foot forward and out to the corner&quot;
+    cue &quot;Step forward onto the right foot with an easy contralateral arm swing&quot;
 
-  step &quot;Close the feet&quot; 0.7s flow:
+  step &quot;Left foot side&quot; 0.85s flow:
     hip_right: flex 0
     knee_right: flex 0
     ankle_right: plantarflex 0
-    shoulders: flex 0
-    travel: -0.35 0.35
-    ground-lock: feet
-    cue &quot;Bring the left foot to meet it, standing tall on the corner&quot;
-
-  step &quot;Step back-left&quot; 0.9s flow:
-    hip_left: flex 35
-    knee_left: flex 40
-    ankle_left: plantarflex 40
-    shoulder_right: flex 25
-    shoulder_left: extend 15
-    travel: 0 0
+    hip_left: abduct 24
+    knee_left: flex 22
+    ankle_left: plantarflex 20
+    shoulder_left: flex 0
+    shoulder_right: flex 20
+    travel: -0.32 0.32
     pin: foot_right floor
-    cue &quot;Step the left foot back to the start on the diagonal&quot;
+    cue &quot;Transfer left to the side, keeping the torso lifted&quot;
 
-  step &quot;Close home&quot; 0.7s settle:
-    hip_left: flex 0
+  step &quot;Right foot back&quot; 0.9s flow:
+    hip_left: abduct 0
     knee_left: flex 0
     ankle_left: plantarflex 0
+    hip_right: extend 18
+    knee_right: flex 30
+    ankle_right: plantarflex 24
+    shoulder_right: flex 0
+    shoulder_left: flex 22
+    travel: -0.32 0
+    pin: foot_left floor
+    cue &quot;Step back onto the right foot to trace the third side of the box&quot;
+
+  step &quot;Left foot closes home&quot; 0.85s settle:
+    hip_right: extend 0
+    knee_right: flex 0
+    ankle_right: plantarflex 0
     shoulders: flex 0
     travel: 0 0
     ground-lock: feet
-    cue &quot;Close the feet together, back home and ready to repeat&quot;
+    cue &quot;Close the left foot and settle over both feet, completing the square&quot;
 
   repeat 4
 </code></pre>

--- a/playground/public/moves/chasse.html
+++ b/playground/public/moves/chasse.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the chassé (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the chassé (dance): 6 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/chasse.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Chassé: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the chassé (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the chassé (dance): 6 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/chasse.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Chassé","description":"How to do the chassé (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Reach & push","text":"Reach the lead foot out and push off to travel sideways"},{"@type":"HowToStep","name":"Gallop close","text":"Chase the trailing foot to the lead: feet meet in the air"},{"@type":"HowToStep","name":"Reach & push back","text":"Change direction and travel back the other way"},{"@type":"HowToStep","name":"Gallop home","text":"Close home, ready to chassé again"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Chassé","description":"How to do the chassé (dance): 6 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Right foot reaches","text":"Reach the right foot sideways and push away from the left leg"},{"@type":"HowToStep","name":"Left foot chases","text":"Let the left foot chase under the body without breaking the sideways flow"},{"@type":"HowToStep","name":"Right foot reaches again","text":"Reach right once more and finish the outward chassé"},{"@type":"HowToStep","name":"Left foot reaches back","text":"Reverse cleanly and reach the left foot back across the floor"},{"@type":"HowToStep","name":"Right foot chases","text":"Let the right foot chase under the body on the return"},{"@type":"HowToStep","name":"Left foot closes home","text":"Close home over both feet and let the momentum resolve"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -135,20 +135,28 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Reach &amp; push<span class="step-dur">0.8s · settle</span></span>
-          <span class="step-cue">Reach the lead foot out and push off to travel sideways</span>
+          <span class="step-name">Right foot reaches<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Reach the right foot sideways and push away from the left leg</span>
         </li>
 <li>
-          <span class="step-name">Gallop close<span class="step-dur">0.6s · drive</span></span>
-          <span class="step-cue">Chase the trailing foot to the lead: feet meet in the air</span>
+          <span class="step-name">Left foot chases<span class="step-dur">0.5s · flow</span></span>
+          <span class="step-cue">Let the left foot chase under the body without breaking the sideways flow</span>
         </li>
 <li>
-          <span class="step-name">Reach &amp; push back<span class="step-dur">0.8s · settle</span></span>
-          <span class="step-cue">Change direction and travel back the other way</span>
+          <span class="step-name">Right foot reaches again<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Reach right once more and finish the outward chassé</span>
         </li>
 <li>
-          <span class="step-name">Gallop home<span class="step-dur">0.6s · drive</span></span>
-          <span class="step-cue">Close home, ready to chassé again</span>
+          <span class="step-name">Left foot reaches back<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Reverse cleanly and reach the left foot back across the floor</span>
+        </li>
+<li>
+          <span class="step-name">Right foot chases<span class="step-dur">0.5s · flow</span></span>
+          <span class="step-cue">Let the right foot chase under the body on the return</span>
+        </li>
+<li>
+          <span class="step-name">Left foot closes home<span class="step-dur">0.7s · settle</span></span>
+          <span class="step-cue">Close home over both feet and let the momentum resolve</span>
         </li>
       </ol>
 
@@ -159,47 +167,73 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Reach &amp; push&quot; 0.8s settle:
-    hip_right: flex 30
-    knee_right: flex 25
-    ankle_right: plantarflex 25
+  step &quot;Right foot reaches&quot; 0.65s flow:
+    hip_right: abduct 26
+    knee_right: flex 20
+    ankle_right: plantarflex 24
     ankle_left: plantarflex 20
     shoulders: abduct 60
     elbows: flex 18
-    travel: 0.5 0
+    travel: 0.34 0
     pin: foot_left floor
     reach: foot_right floor
-    cue &quot;Reach the lead foot out and push off to travel sideways&quot;
+    cue &quot;Reach the right foot sideways and push away from the left leg&quot;
 
-  step &quot;Gallop close&quot; 0.6s drive:
-    hip_right: flex 0
+  step &quot;Left foot chases&quot; 0.5s flow:
+    hip_right: abduct 0
     knee_right: flex 0
     ankle_right: plantarflex 0
-    ankle_left: plantarflex 0
-    travel: 0.9 0
-    ground-lock: feet
-    cue &quot;Chase the trailing foot to the lead: feet meet in the air&quot;
+    hip_left: abduct 18
+    knee_left: flex 22
+    ankle_left: plantarflex 24
+    travel: 0.66 0
+    pin: foot_right floor
+    cue &quot;Let the left foot chase under the body without breaking the sideways flow&quot;
 
-  step &quot;Reach &amp; push back&quot; 0.8s settle:
-    hip_left: flex 30
-    knee_left: flex 25
-    ankle_left: plantarflex 25
+  step &quot;Right foot reaches again&quot; 0.65s flow:
+    hip_left: abduct 0
+    knee_left: flex 0
+    ankle_left: plantarflex 18
+    hip_right: abduct 26
+    knee_right: flex 20
+    ankle_right: plantarflex 24
+    travel: 1 0
+    pin: foot_left floor
+    reach: foot_right floor
+    cue &quot;Reach right once more and finish the outward chassé&quot;
+
+  step &quot;Left foot reaches back&quot; 0.65s flow:
+    hip_right: abduct 0
+    knee_right: flex 0
     ankle_right: plantarflex 20
-    travel: 0.4 0
+    hip_left: abduct 26
+    knee_left: flex 20
+    ankle_left: plantarflex 24
+    travel: 0.66 0
     pin: foot_right floor
     reach: foot_left floor
-    cue &quot;Change direction and travel back the other way&quot;
+    cue &quot;Reverse cleanly and reach the left foot back across the floor&quot;
 
-  step &quot;Gallop home&quot; 0.6s drive:
-    hip_left: flex 0
+  step &quot;Right foot chases&quot; 0.5s flow:
+    hip_left: abduct 0
     knee_left: flex 0
     ankle_left: plantarflex 0
-    ankle_right: plantarflex 0
+    hip_right: abduct 18
+    knee_right: flex 22
+    ankle_right: plantarflex 24
+    travel: 0.34 0
+    pin: foot_left floor
+    cue &quot;Let the right foot chase under the body on the return&quot;
+
+  step &quot;Left foot closes home&quot; 0.7s settle:
+    hip_right: abduct 0
+    knee_right: flex 0
+    ankles: plantarflex 0
     shoulders: abduct 0
     elbows: flex 0
     travel: 0 0
     ground-lock: feet
-    cue &quot;Close home, ready to chassé again&quot;
+    cue &quot;Close home over both feet and let the momentum resolve&quot;
 
   repeat 4
 </code></pre>

--- a/playground/public/moves/dance-phrase.html
+++ b/playground/public/moves/dance-phrase.html
@@ -147,7 +147,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
           <span class="step-cue">Press up to relevé and lift the arms into a frame overhead</span>
         </li>
 <li>
-          <span class="step-name">7-8 - close<span class="step-dur">2s · settle</span></span>
+          <span class="step-name">7-8 - close<span class="step-dur">2.2s · settle</span></span>
           <span class="step-cue">Lower the heels and resolve, arms floating back to the sides</span>
         </li>
       </ol>
@@ -170,7 +170,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   step &quot;3-4 - demi-plié&quot; 2s flow:
     hips: flex 18
     knees: flex 50
-    ankles: plantarflex 50
+    ankles: dorsiflex 12
     shoulders: flex 28
     elbows: flex 30
     ground-lock: feet
@@ -186,7 +186,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     ground-lock: feet
     cue &quot;Press up to relevé and lift the arms into a frame overhead&quot;
 
-  step &quot;7-8 - close&quot; 2s settle:
+  step &quot;7-8 - close&quot; 2.2s settle:
     ankles: plantarflex 0
     hips: rotate-out 0
     shoulders: flex 0

--- a/playground/public/moves/demi-plie.html
+++ b/playground/public/moves/demi-plie.html
@@ -135,11 +135,11 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Plié<span class="step-dur">2s · flow</span></span>
+          <span class="step-name">Plié<span class="step-dur">2.2s · settle</span></span>
           <span class="step-cue">Turn out from the hips and bend the knees over the toes: heels down</span>
         </li>
 <li>
-          <span class="step-name">Straighten<span class="step-dur">2s · settle</span></span>
+          <span class="step-name">Straighten<span class="step-dur">2.2s · settle</span></span>
           <span class="step-cue">Press the floor away and rise to a tall first position</span>
         </li>
       </ol>
@@ -151,7 +151,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Plié&quot; 2s flow:
+  step &quot;Plié&quot; 2.2s settle:
     hips: flex 20
     hips: rotate-out 30
     knees: flex 55
@@ -162,7 +162,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     ground-lock: feet
     cue &quot;Turn out from the hips and bend the knees over the toes: heels down&quot;
 
-  step &quot;Straighten&quot; 2s settle:
+  step &quot;Straighten&quot; 2.2s settle:
     hips: flex 0
     hips: rotate-out 0
     knees: flex 0

--- a/playground/public/moves/forward-lunge.html
+++ b/playground/public/moves/forward-lunge.html
@@ -156,7 +156,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     knee_right: flex 95
     hip_left: extend 15
     knee_left: flex 80
-    ankle_right: plantarflex 50
+    ankle_left: plantarflex 50
     spine: extend 4
     travel: 0 0.3
     pin: foot_left floor
@@ -168,7 +168,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     knee_right: flex 0
     hip_left: extend 0
     knee_left: flex 0
-    ankle_right: plantarflex 0
+    ankle_left: plantarflex 0
     spine: flex 0
     travel: 0 0
     ground-lock: feet

--- a/playground/public/moves/grapevine.html
+++ b/playground/public/moves/grapevine.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the grapevine (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the grapevine (dance): 8 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/grapevine.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Grapevine: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the grapevine (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the grapevine (dance): 8 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/grapevine.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Grapevine","description":"How to do the grapevine (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Step out","text":"Step the leading foot out to the side"},{"@type":"HowToStep","name":"Cross behind","text":"Cross the trailing foot behind and keep travelling"},{"@type":"HowToStep","name":"Step out again","text":"Step out to the side once more"},{"@type":"HowToStep","name":"Return home","text":"Travel back the other way to the starting spot"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Grapevine","description":"How to do the grapevine (dance): 8 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Left step side","text":"Step the left foot to the side and begin travelling"},{"@type":"HowToStep","name":"Right crosses behind","text":"Cross the right foot behind without stopping the sideways momentum"},{"@type":"HowToStep","name":"Left step side again","text":"Step left again and keep the shoulders quiet"},{"@type":"HowToStep","name":"Right touch","text":"Touch the right foot in lightly before reversing"},{"@type":"HowToStep","name":"Right step side","text":"Step the right foot to the side to travel back"},{"@type":"HowToStep","name":"Left crosses behind","text":"Cross the left foot behind and continue through the beat"},{"@type":"HowToStep","name":"Right step side again","text":"Step right and arrive back near the starting place"},{"@type":"HowToStep","name":"Close home","text":"Close the left foot under the body and settle the phrase"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -135,20 +135,36 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Step out<span class="step-dur">0.7s · flow</span></span>
-          <span class="step-cue">Step the leading foot out to the side</span>
+          <span class="step-name">Left step side<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Step the left foot to the side and begin travelling</span>
         </li>
 <li>
-          <span class="step-name">Cross behind<span class="step-dur">0.7s · flow</span></span>
-          <span class="step-cue">Cross the trailing foot behind and keep travelling</span>
+          <span class="step-name">Right crosses behind<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Cross the right foot behind without stopping the sideways momentum</span>
         </li>
 <li>
-          <span class="step-name">Step out again<span class="step-dur">0.7s · flow</span></span>
-          <span class="step-cue">Step out to the side once more</span>
+          <span class="step-name">Left step side again<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Step left again and keep the shoulders quiet</span>
         </li>
 <li>
-          <span class="step-name">Return home<span class="step-dur">1s · settle</span></span>
-          <span class="step-cue">Travel back the other way to the starting spot</span>
+          <span class="step-name">Right touch<span class="step-dur">0.55s · flow</span></span>
+          <span class="step-cue">Touch the right foot in lightly before reversing</span>
+        </li>
+<li>
+          <span class="step-name">Right step side<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Step the right foot to the side to travel back</span>
+        </li>
+<li>
+          <span class="step-name">Left crosses behind<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Cross the left foot behind and continue through the beat</span>
+        </li>
+<li>
+          <span class="step-name">Right step side again<span class="step-dur">0.65s · flow</span></span>
+          <span class="step-cue">Step right and arrive back near the starting place</span>
+        </li>
+<li>
+          <span class="step-name">Close home<span class="step-dur">0.65s · settle</span></span>
+          <span class="step-cue">Close the left foot under the body and settle the phrase</span>
         </li>
       </ol>
 
@@ -159,40 +175,77 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Step out&quot; 0.7s flow:
-    hip_left: abduct 30
+  step &quot;Left step side&quot; 0.65s flow:
+    hip_left: abduct 28
     shoulders: abduct 40
-    travel: 0.4 0
+    travel: 0.3 0
     pin: foot_right floor
     reach: foot_left floor
-    cue &quot;Step the leading foot out to the side&quot;
+    cue &quot;Step the left foot to the side and begin travelling&quot;
 
-  step &quot;Cross behind&quot; 0.7s flow:
+  step &quot;Right crosses behind&quot; 0.65s flow:
     hip_left: abduct 0
     hip_right: rotate-in 20
     knee_right: flex 25
     ankle_right: plantarflex 25
-    travel: 0.8 0
+    travel: 0.6 0
     pin: foot_left floor
     reach: foot_right floor
-    cue &quot;Cross the trailing foot behind and keep travelling&quot;
+    cue &quot;Cross the right foot behind without stopping the sideways momentum&quot;
 
-  step &quot;Step out again&quot; 0.7s flow:
+  step &quot;Left step side again&quot; 0.65s flow:
     hip_right: rotate-in 0
     knee_right: flex 0
     ankle_right: plantarflex 0
-    hip_left: abduct 30
-    travel: 1.2 0
+    hip_left: abduct 28
+    travel: 0.9 0
     pin: foot_right floor
     reach: foot_left floor
-    cue &quot;Step out to the side once more&quot;
+    cue &quot;Step left again and keep the shoulders quiet&quot;
 
-  step &quot;Return home&quot; 1s settle:
+  step &quot;Right touch&quot; 0.55s flow:
     hip_left: abduct 0
+    knee_right: flex 16
+    ankle_right: plantarflex 20
+    travel: 1 0
+    ground-lock: feet
+    cue &quot;Touch the right foot in lightly before reversing&quot;
+
+  step &quot;Right step side&quot; 0.65s flow:
+    knee_right: flex 0
+    ankle_right: plantarflex 0
+    hip_right: abduct 28
+    travel: 0.7 0
+    pin: foot_left floor
+    reach: foot_right floor
+    cue &quot;Step the right foot to the side to travel back&quot;
+
+  step &quot;Left crosses behind&quot; 0.65s flow:
+    hip_right: abduct 0
+    hip_left: rotate-in 20
+    knee_left: flex 25
+    ankle_left: plantarflex 25
+    travel: 0.4 0
+    pin: foot_right floor
+    reach: foot_left floor
+    cue &quot;Cross the left foot behind and continue through the beat&quot;
+
+  step &quot;Right step side again&quot; 0.65s flow:
+    hip_left: rotate-in 0
+    knee_left: flex 0
+    ankle_left: plantarflex 0
+    hip_right: abduct 28
+    travel: 0.1 0
+    pin: foot_left floor
+    reach: foot_right floor
+    cue &quot;Step right and arrive back near the starting place&quot;
+
+  step &quot;Close home&quot; 0.65s settle:
+    hip_right: abduct 0
     shoulders: abduct 0
     travel: 0 0
     ground-lock: feet
-    cue &quot;Travel back the other way to the starting spot&quot;
+    cue &quot;Close the left foot under the body and settle the phrase&quot;
 
   repeat 3
 </code></pre>

--- a/playground/public/moves/index.html
+++ b/playground/public/moves/index.html
@@ -176,8 +176,8 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
                 <span class="mc-meta">Lats · Bar · Advanced</span>
               </a>
 <a class="move-card" href="/moves/triceps-dips.html">
-                <span class="mc-name">Triceps dips (chair)</span>
-                <span class="mc-meta">Triceps · Chair · Intermediate</span>
+                <span class="mc-name">Triceps dips (bars)</span>
+                <span class="mc-meta">Triceps · Bars · Intermediate</span>
               </a>
 <a class="move-card" href="/moves/bent-over-row.html">
                 <span class="mc-name">Bent-over row (hinge)</span>

--- a/playground/public/moves/jumping-jacks.html
+++ b/playground/public/moves/jumping-jacks.html
@@ -149,6 +149,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
         angles, not 3D transforms.</p>
       <pre class="code-block"><code>posecode exercise &quot;Jumping jacks&quot;
   rig humanoid
+  clip &quot;jumping-jacks&quot;
   pose start = standing
 
   step &quot;Out&quot; 0.5s settle:

--- a/playground/public/moves/pirouette.html
+++ b/playground/public/moves/pirouette.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the pirouette (dance): 3 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the pirouette (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/pirouette.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Pirouette: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the pirouette (dance): 3 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the pirouette (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/pirouette.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Pirouette","description":"How to do the pirouette (dance): 3 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Prep - plié","text":"Plié to load the turn, arms rounded low in first"},{"@type":"HowToStep","name":"Spot & spin","text":"Push up to relevé, pull the arms in, and spin a full turn"},{"@type":"HowToStep","name":"Land","text":"Land softly through the feet, arms floating back to the sides"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Pirouette","description":"How to do the pirouette (dance): 4 phases targeting the full body, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Prep - plié","text":"Plié to load the turn, arms rounded low in first"},{"@type":"HowToStep","name":"Spot & spin","text":"Push up to relevé, pull the arms in, and spin a full turn"},{"@type":"HowToStep","name":"Land through plié","text":"Finish the turn and absorb the landing through a soft plié"},{"@type":"HowToStep","name":"Recover","text":"Lengthen to standing and let the arms float back to the sides"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -143,8 +143,12 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
           <span class="step-cue">Push up to relevé, pull the arms in, and spin a full turn</span>
         </li>
 <li>
-          <span class="step-name">Land<span class="step-dur">1s · settle</span></span>
-          <span class="step-cue">Land softly through the feet, arms floating back to the sides</span>
+          <span class="step-name">Land through plié<span class="step-dur">0.9s · settle</span></span>
+          <span class="step-cue">Finish the turn and absorb the landing through a soft plié</span>
+        </li>
+<li>
+          <span class="step-name">Recover<span class="step-dur">1.1s · settle</span></span>
+          <span class="step-cue">Lengthen to standing and let the arms float back to the sides</span>
         </li>
       </ol>
 
@@ -158,7 +162,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   step &quot;Prep - plié&quot; 1.2s flow:
     hips: rotate-out 25
     knees: flex 45
-    ankles: plantarflex 45
+    ankles: dorsiflex 12
     shoulders: flex 40
     elbows: flex 35
     ground-lock: feet
@@ -177,15 +181,28 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     pin: foot_left floor
     cue &quot;Push up to relevé, pull the arms in, and spin a full turn&quot;
 
-  step &quot;Land&quot; 1s settle:
+  step &quot;Land through plié&quot; 0.9s settle:
+    hip_right: flex 0
+    hip_right: rotate-out 0
+    knee_right: flex 28
+    ankle_right: dorsiflex 8
+    knee_left: flex 28
+    ankle_left: dorsiflex 8
+    shoulders: abduct 55
+    shoulders: flex 0
+    elbows: flex 18
+    ground-lock: feet
+    cue &quot;Finish the turn and absorb the landing through a soft plié&quot;
+
+  step &quot;Recover&quot; 1.1s settle:
     hips: flex 0
     hips: rotate-out 0
     knees: flex 0
-    ankles: plantarflex 0
-    shoulders: flex 0
+    ankles: dorsiflex 0
+    shoulders: abduct 0
     elbows: flex 0
     ground-lock: feet
-    cue &quot;Land softly through the feet, arms floating back to the sides&quot;
+    cue &quot;Lengthen to standing and let the arms float back to the sides&quot;
 
   repeat 3
 </code></pre>

--- a/playground/public/moves/port-de-bras.html
+++ b/playground/public/moves/port-de-bras.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the port de bras (dance): 4 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the port de bras (dance): 5 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/port-de-bras.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Port de bras: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the port de bras (dance): 4 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the port de bras (dance): 5 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/port-de-bras.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Port de bras","description":"How to do the port de bras (dance): 4 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"First position","text":"Arms rounded low in front: first position, shoulders soft"},{"@type":"HowToStep","name":"Second position","text":"Open the arms out to the sides: second position, wrists lifted"},{"@type":"HowToStep","name":"Fifth en haut","text":"Float the arms into a rounded frame overhead: fifth position"},{"@type":"HowToStep","name":"Lower","text":"Lower through second back to the start, eyes following the hands"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Port de bras","description":"How to do the port de bras (dance): 5 phases targeting the deltoids, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"First position","text":"Arms rounded low in front: first position, shoulders soft"},{"@type":"HowToStep","name":"Second position","text":"Open the arms out to the sides: second position, wrists lifted"},{"@type":"HowToStep","name":"Fifth en haut","text":"Float the arms into a rounded frame overhead: fifth position"},{"@type":"HowToStep","name":"Open down through second","text":"Open from overhead through a wide second position, shoulders released"},{"@type":"HowToStep","name":"Close low","text":"Float the arms down to the start, eyes following the hands"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -143,12 +143,16 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
           <span class="step-cue">Open the arms out to the sides: second position, wrists lifted</span>
         </li>
 <li>
-          <span class="step-name">Fifth en haut<span class="step-dur">2.2s · flow</span></span>
+          <span class="step-name">Fifth en haut<span class="step-dur">2.4s · flow</span></span>
           <span class="step-cue">Float the arms into a rounded frame overhead: fifth position</span>
         </li>
 <li>
-          <span class="step-name">Lower<span class="step-dur">2s · settle</span></span>
-          <span class="step-cue">Lower through second back to the start, eyes following the hands</span>
+          <span class="step-name">Open down through second<span class="step-dur">2.2s · flow</span></span>
+          <span class="step-cue">Open from overhead through a wide second position, shoulders released</span>
+        </li>
+<li>
+          <span class="step-name">Close low<span class="step-dur">2s · settle</span></span>
+          <span class="step-cue">Float the arms down to the start, eyes following the hands</span>
         </li>
       </ol>
 
@@ -173,19 +177,27 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     ground-lock: feet
     cue &quot;Open the arms out to the sides: second position, wrists lifted&quot;
 
-  step &quot;Fifth en haut&quot; 2.2s flow:
+  step &quot;Fifth en haut&quot; 2.4s flow:
     shoulders: abduct 0
     shoulders: flex 160
     elbows: flex 20
     ground-lock: feet
     cue &quot;Float the arms into a rounded frame overhead: fifth position&quot;
 
-  step &quot;Lower&quot; 2s settle:
+  step &quot;Open down through second&quot; 2.2s flow:
+    shoulders: flex 0
+    shoulders: abduct 85
+    elbows: flex 16
+    ground-lock: feet
+    cue &quot;Open from overhead through a wide second position, shoulders released&quot;
+
+  step &quot;Close low&quot; 2s settle:
+    shoulders: abduct 0
     shoulders: flex 0
     elbows: flex 0
     hips: rotate-out 0
     ground-lock: feet
-    cue &quot;Lower through second back to the start, eyes following the hands&quot;
+    cue &quot;Float the arms down to the start, eyes following the hands&quot;
 
   repeat 3
 </code></pre>

--- a/playground/public/moves/releve.html
+++ b/playground/public/moves/releve.html
@@ -135,11 +135,11 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Rise<span class="step-dur">1.6s · settle</span></span>
+          <span class="step-name">Rise<span class="step-dur">1.8s · settle</span></span>
           <span class="step-cue">Turn out and rise onto the balls of the feet: lengthen up tall</span>
         </li>
 <li>
-          <span class="step-name">Lower<span class="step-dur">1.8s · drive</span></span>
+          <span class="step-name">Lower<span class="step-dur">2s · settle</span></span>
           <span class="step-cue">Lower the heels with control, staying lifted through the spine</span>
         </li>
       </ol>
@@ -151,7 +151,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Rise&quot; 1.6s settle:
+  step &quot;Rise&quot; 1.8s settle:
     ankles: plantarflex 30
     hips: rotate-out 25
     knees: extend 0
@@ -161,7 +161,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     ground-lock: feet
     cue &quot;Turn out and rise onto the balls of the feet: lengthen up tall&quot;
 
-  step &quot;Lower&quot; 1.8s drive:
+  step &quot;Lower&quot; 2s settle:
     ankles: plantarflex 0
     hips: rotate-out 0
     shoulders: abduct 0

--- a/playground/public/moves/superman.html
+++ b/playground/public/moves/superman.html
@@ -152,7 +152,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   pose start = prone
 
   step &quot;Lift&quot; 1.5s settle:
-    shoulders: abduct 130
+    shoulders: flex 140
     spine: extend 20
     chest: extend 15
     neck: extend 25
@@ -161,7 +161,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     cue &quot;Lift the arms, chest, and legs off the floor&quot;
 
   step &quot;Lower&quot; 1.5s drive:
-    shoulders: abduct 0
+    shoulders: flex 0
     spine: flex 0
     chest: flex 0
     neck: flex 0

--- a/playground/public/moves/tendu.html
+++ b/playground/public/moves/tendu.html
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Tendu","description":"How to do the tendu (dance): 2 phases targeting the hip flexors, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Point front","text":"Brush the right foot forward to a fully pointed tendu, leg turned out"},{"@type":"HowToStep","name":"Close","text":"Draw the foot back to first position, heel down"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Tendu","description":"How to do the tendu (dance): 2 phases targeting the hip flexors, body weight, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Brush and point","text":"Brush the right foot forward to a fully pointed tendu, leg turned out"},{"@type":"HowToStep","name":"Close through the floor","text":"Draw the foot back to first position, heel down"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -135,11 +135,11 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">Point front<span class="step-dur">1.6s · flow</span></span>
+          <span class="step-name">Brush and point<span class="step-dur">1.8s · settle</span></span>
           <span class="step-cue">Brush the right foot forward to a fully pointed tendu, leg turned out</span>
         </li>
 <li>
-          <span class="step-name">Close<span class="step-dur">1.6s · settle</span></span>
+          <span class="step-name">Close through the floor<span class="step-dur">1.8s · settle</span></span>
           <span class="step-cue">Draw the foot back to first position, heel down</span>
         </li>
       </ol>
@@ -151,7 +151,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;Point front&quot; 1.6s flow:
+  step &quot;Brush and point&quot; 1.8s settle:
     hip_right: flex 22
     hip_right: rotate-out 30
     knee_right: extend 0
@@ -161,7 +161,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     pin: foot_left floor
     cue &quot;Brush the right foot forward to a fully pointed tendu, leg turned out&quot;
 
-  step &quot;Close&quot; 1.6s settle:
+  step &quot;Close through the floor&quot; 1.8s settle:
     hip_right: flex 0
     hip_right: rotate-out 0
     ankle_right: plantarflex 0

--- a/playground/public/moves/triceps-dips.html
+++ b/playground/public/moves/triceps-dips.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the triceps dips (fitness): 4 phases targeting the triceps, chair, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the triceps dips (fitness): 4 phases targeting the triceps, bars, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/triceps-dips.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Triceps dips: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the triceps dips (fitness): 4 phases targeting the triceps, chair, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the triceps dips (fitness): 4 phases targeting the triceps, bars, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/triceps-dips.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Triceps dips","description":"How to do the triceps dips (fitness): 4 phases targeting the triceps, chair, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Support","text":"Press up to a straight-arm support between the bars"},{"@type":"HowToStep","name":"Lower","text":"Bend the elbows to lower the chest, elbows tracking back"},{"@type":"HowToStep","name":"Press","text":"Press through the palms to straighten the arms"},{"@type":"HowToStep","name":"Dismount","text":"Step down and stand tall"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Triceps dips","description":"How to do the triceps dips (fitness): 4 phases targeting the triceps, bars, intermediate level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"Support","text":"Press up to a straight-arm support between the bars"},{"@type":"HowToStep","name":"Lower","text":"Bend the elbows to lower the chest, elbows tracking back"},{"@type":"HowToStep","name":"Press","text":"Press through the palms to straighten the arms"},{"@type":"HowToStep","name":"Dismount","text":"Step down and stand tall"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -123,7 +123,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       
       <p class="eyebrow">Fitness · Upper arms</p>
       <h1>Triceps dips</h1>
-      <p class="meta-line"><b>Target</b> Triceps &nbsp;·&nbsp; <b>Equipment</b> Chair
+      <p class="meta-line"><b>Target</b> Triceps &nbsp;·&nbsp; <b>Equipment</b> Bars
         &nbsp;·&nbsp; <b>Level</b> Intermediate &nbsp;·&nbsp; <b>Reps</b> 8</p>
       <p>Triceps dips is a intermediate-level fitness movement targeting the
         triceps, written in <a href="/">Posecode</a>, a small open-source language

--- a/playground/public/moves/waltz-box.html
+++ b/playground/public/moves/waltz-box.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="How to do the waltz box step (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta name="description" content="How to do the waltz box step (dance): 6 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <link rel="canonical" href="https://posecode.org/moves/waltz-box.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Waltz box step: How to Do It (Animated 3D Guide) | Posecode" />
-    <meta property="og:description" content="How to do the waltz box step (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
+    <meta property="og:description" content="How to do the waltz box step (dance): 6 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/moves/waltz-box.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -99,7 +99,7 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 @media(max-width:600px){.wrap{padding:0 18px}}
 </style>
     <link rel="stylesheet" href="/content-theme.css" />
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Waltz box step","description":"How to do the waltz box step (dance): 4 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"1 - forward, rise","text":"Step forward onto the right foot and rise, arms in a soft frame"},{"@type":"HowToStep","name":"2 - side, lower","text":"Side step to the corner and lower through the heels"},{"@type":"HowToStep","name":"3 - back, rise","text":"Step back onto the left foot and rise again"},{"@type":"HowToStep","name":"4 - close home","text":"Close to the start, completing the box"}]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to do a Waltz box step","description":"How to do the waltz box step (dance): 6 phases targeting the full body, body weight, beginner level. Animated 3D guide generated from Posecode, a text-to-motion language for LLMs.","step":[{"@type":"HowToStep","name":"1 - right foot forward","text":"Step forward onto the right foot and begin the waltz rise"},{"@type":"HowToStep","name":"2 - left foot side","text":"Step left to the side and continue rising through count two"},{"@type":"HowToStep","name":"3 - close and lower","text":"Close the right foot to the left and lower softly through count three"},{"@type":"HowToStep","name":"4 - left foot back","text":"Step back onto the left foot and begin the second rise"},{"@type":"HowToStep","name":"5 - right foot side","text":"Step right to the side, staying buoyant through count five"},{"@type":"HowToStep","name":"6 - close and lower","text":"Close the left foot and lower with control to complete the six-count box"}]}</script>
     <script>
       window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
@@ -135,20 +135,28 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       <h2>How to do it</h2>
       <ol class="steps">
 <li>
-          <span class="step-name">1 - forward, rise<span class="step-dur">1s · flow</span></span>
-          <span class="step-cue">Step forward onto the right foot and rise, arms in a soft frame</span>
+          <span class="step-name">1 - right foot forward<span class="step-dur">0.95s · flow</span></span>
+          <span class="step-cue">Step forward onto the right foot and begin the waltz rise</span>
         </li>
 <li>
-          <span class="step-name">2 - side, lower<span class="step-dur">1s · flow</span></span>
-          <span class="step-cue">Side step to the corner and lower through the heels</span>
+          <span class="step-name">2 - left foot side<span class="step-dur">0.95s · flow</span></span>
+          <span class="step-cue">Step left to the side and continue rising through count two</span>
         </li>
 <li>
-          <span class="step-name">3 - back, rise<span class="step-dur">1s · flow</span></span>
-          <span class="step-cue">Step back onto the left foot and rise again</span>
+          <span class="step-name">3 - close and lower<span class="step-dur">1.05s · flow</span></span>
+          <span class="step-cue">Close the right foot to the left and lower softly through count three</span>
         </li>
 <li>
-          <span class="step-name">4 - close home<span class="step-dur">1s · settle</span></span>
-          <span class="step-cue">Close to the start, completing the box</span>
+          <span class="step-name">4 - left foot back<span class="step-dur">0.95s · flow</span></span>
+          <span class="step-cue">Step back onto the left foot and begin the second rise</span>
+        </li>
+<li>
+          <span class="step-name">5 - right foot side<span class="step-dur">0.95s · flow</span></span>
+          <span class="step-cue">Step right to the side, staying buoyant through count five</span>
+        </li>
+<li>
+          <span class="step-name">6 - close and lower<span class="step-dur">1.05s · settle</span></span>
+          <span class="step-cue">Close the left foot and lower with control to complete the six-count box</span>
         </li>
       </ol>
 
@@ -159,41 +167,63 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
   rig humanoid
   pose start = standing
 
-  step &quot;1 - forward, rise&quot; 1s flow:
-    hip_right: flex 25
-    knee_right: flex 20
-    ankles: plantarflex 12
+  step &quot;1 - right foot forward&quot; 0.95s flow:
+    hip_right: flex 24
+    knee_right: flex 24
+    ankle_right: plantarflex 18
     shoulders: abduct 55
     elbows: flex 20
-    travel: 0 0.4
+    travel: 0 0.32
     pin: foot_left floor
-    cue &quot;Step forward onto the right foot and rise, arms in a soft frame&quot;
+    cue &quot;Step forward onto the right foot and begin the waltz rise&quot;
 
-  step &quot;2 - side, lower&quot; 1s flow:
+  step &quot;2 - left foot side&quot; 0.95s flow:
     hip_right: flex 0
     knee_right: flex 0
-    ankles: plantarflex 0
-    travel: -0.4 0.4
-    ground-lock: feet
-    cue &quot;Side step to the corner and lower through the heels&quot;
-
-  step &quot;3 - back, rise&quot; 1s flow:
-    hip_left: flex 25
-    knee_left: flex 20
-    ankles: plantarflex 12
-    travel: -0.4 0
+    ankle_right: plantarflex 0
+    hip_left: abduct 22
+    knee_left: flex 16
+    ankles: plantarflex 22
+    travel: -0.32 0.32
     pin: foot_right floor
-    cue &quot;Step back onto the left foot and rise again&quot;
+    cue &quot;Step left to the side and continue rising through count two&quot;
 
-  step &quot;4 - close home&quot; 1s settle:
-    hip_left: flex 0
+  step &quot;3 - close and lower&quot; 1.05s flow:
+    hip_left: abduct 0
     knee_left: flex 0
+    ankles: plantarflex 0
+    travel: -0.32 0.32
+    ground-lock: feet
+    cue &quot;Close the right foot to the left and lower softly through count three&quot;
+
+  step &quot;4 - left foot back&quot; 0.95s flow:
+    hip_left: extend 18
+    knee_left: flex 24
+    ankle_left: plantarflex 18
+    travel: -0.32 0
+    pin: foot_right floor
+    cue &quot;Step back onto the left foot and begin the second rise&quot;
+
+  step &quot;5 - right foot side&quot; 0.95s flow:
+    hip_left: extend 0
+    knee_left: flex 0
+    ankle_left: plantarflex 0
+    hip_right: abduct 22
+    knee_right: flex 16
+    ankles: plantarflex 22
+    travel: 0 0
+    pin: foot_left floor
+    cue &quot;Step right to the side, staying buoyant through count five&quot;
+
+  step &quot;6 - close and lower&quot; 1.05s settle:
+    hip_right: abduct 0
+    knee_right: flex 0
     ankles: plantarflex 0
     shoulders: abduct 0
     elbows: flex 0
     travel: 0 0
     ground-lock: feet
-    cue &quot;Close to the start, completing the box&quot;
+    cue &quot;Close the left foot and lower with control to complete the six-count box&quot;
 
   repeat 3
 </code></pre>

--- a/playground/public/sitemap.xml
+++ b/playground/public/sitemap.xml
@@ -2,463 +2,463 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://posecode.org/</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://posecode.org/play</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://posecode.org/spec.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://posecode.org/llm-guide.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/squat.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/dance-phrase.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/deadlift.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/shoulder-abduction.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/front-kick.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/good-morning.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/chest-opener.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/plank-hold.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/mountain-climber.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/crunch.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/bicycle-crunch.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/supine-leg-raise.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/superman.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/forward-lunge.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/calf-raise.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/jumping-jacks.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/box-step-taps.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/pull-up.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/step-up.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/triceps-dips.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/quad-stretch.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/hip-flexion.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/knee-flexion.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/spine-rotation.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/elbow-forearm.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/heel-raises.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/hamstring-curl.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/hip-abduction.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/shoulder.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/neck.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/posture.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/twist.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/shoulder-rolls.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/neck-side-stretch.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/overhead-reach.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/jab-cross.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/horse-stance.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/bow.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/arm-circles.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/high-knee-march.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/demi-plie.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/releve.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/tendu.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/port-de-bras.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/bent-over-row.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/biceps.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/lateral.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/fold.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/chair.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/sidebend.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/touch-toes.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/cross-body-reach.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/glute-bridge.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/dead-bug.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/cobra.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/seated-forward-fold.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/sit-to-stand.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/box-squat.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/wall-sit.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/dead-hang.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/hanging-knee-raise.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/make-a-fist.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/pinch-grip.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/finger-spell.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/hand-wave.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/pirouette.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/box-step.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/grapevine.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/waltz-box.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/chasse.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/walk-cycle.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://posecode.org/moves/quarter-turns.html</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/playground/public/spec.html
+++ b/playground/public/spec.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <meta name="description" content="The full Posecode v0.1 grammar, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure." />
+    <meta name="description" content="The full Posecode v0.2 grammar, timing modes, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure." />
     <link rel="canonical" href="https://posecode.org/spec.html" />
     <meta name="theme-color" content="#0a0d12" />
     <meta property="og:title" content="Posecode Language Specification: The .posecode Kinematic Motion DSL" />
-    <meta property="og:description" content="The full Posecode v0.1 grammar, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure." />
+    <meta property="og:description" content="The full Posecode v0.2 grammar, timing modes, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://posecode.org/spec.html" />
     <meta property="og:site_name" content="Posecode" />
@@ -121,10 +121,10 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
     </header>
     <main class="wrap">
       <p class="eyebrow">Reference</p>
-<h1>Posecode Protocol Specification v0.1</h1>
+<h1>Posecode Protocol Specification v0.2</h1>
 <p>Posecode is a small text language for describing a single person's <strong>kinematic movement</strong> so it can be rendered as an animated 3D figure in a web browser.</p>
 <p>It is to human movement what Mermaid is to diagrams: an LLM (or a human) writes a compact, readable document; a client-side parser + renderer turns it into a moving mannequin. The model never produces 3D matrices: it expresses the *semantic phases* of a movement, which it already understands.</p>
-<ul><li><strong>Version keyword:</strong> documents declare nothing; this is <code>posecode 0.1</code>.</li><li><strong>File extension:</strong> <code>.posecode</code></li><li><strong>Compute model:</strong> generation is pure text (server-cheap); all 3D math runs</li></ul>
+<ul><li><strong>Version keyword:</strong> documents declare nothing; this is <code>posecode 0.2</code>.</li><li><strong>Compatibility:</strong> v0.2 parsers continue to accept the v0.1 easing aliases.</li><li><strong>File extension:</strong> <code>.posecode</code></li><li><strong>Compute model:</strong> generation is pure text (server-cheap); all 3D math runs</li></ul>
 <p>on the client (Three.js). See the project research §6.</p>
 <hr>
 <h2>1. Grammar</h2>
@@ -138,8 +138,8 @@ prop       = &quot;prop&quot; WORD ;                              (* chair|wall|
 pose       = &quot;pose&quot; &quot;start&quot; &quot;=&quot; WORD ;                  (* neutral|standing|plank|supine|prone|seated *)
 clip       = &quot;clip&quot; STRING ;                            (* optional mocap clip; renderer may retarget &amp; blend *)
 repeat     = &quot;repeat&quot; NUMBER ;
-step       = &quot;step&quot; STRING DURATION easing &quot;:&quot; { child } ;
-easing     = &quot;linear&quot; | &quot;ease-in&quot; | &quot;ease-out&quot; | &quot;ease-in-out&quot; ;
+step       = &quot;step&quot; STRING DURATION timingMode &quot;:&quot; { child } ;
+timingMode = &quot;flow&quot; | &quot;settle&quot; | &quot;drive&quot; | &quot;snap&quot; | &quot;linear&quot; ;
 child      = jointTarget | groundLock | reach | pin | turn | travel | cue ;
 jointTarget= joint &quot;:&quot; action [ NUMBER ] ;
 groundLock = &quot;ground-lock&quot; &quot;:&quot; effector { &quot;,&quot; effector } ;
@@ -150,6 +150,16 @@ travel     = &quot;travel&quot; &quot;:&quot; NUMBER NUMBER ;              (* mo
 cue        = &quot;cue&quot; STRING ;
 DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1.5s *)</code></pre>
 <p>A <code>step</code> is one <strong>phase</strong> of the movement. Phases run in sequence; within a phase, all joint targets apply concurrently.</p>
+<p>Ground locks accept the groups <code>hands</code>, <code>forearms</code>, and <code>feet</code>, plus the single-side forms <code>hand_left|hand_right</code>, <code>elbow_left|elbow_right</code>, and <code>foot_left|foot_right</code>. Human-readable <code>left foot</code>, <code>right foot</code>, <code>left hand</code>, and related forms normalize to the canonical side-specific names.</p>
+<p>Timing modes describe how motion crosses the phase boundary:</p>
+<div class="table-wrap"><table><thead><tr><th>Mode</th><th>Use</th></tr></thead><tbody>
+<tr><td><code>flow</code></td><td>Carry velocity smoothly through the pose.</td></tr>
+<tr><td><code>settle</code></td><td>Decelerate into a deliberate rest.</td></tr>
+<tr><td><code>drive</code></td><td>Accelerate out of rest.</td></tr>
+<tr><td><code>snap</code></td><td>Arrive quickly and stop sharply.</td></tr>
+<tr><td><code>linear</code></td><td>Even timing without a shaped acceleration curve.</td></tr>
+</tbody></table></div>
+<p>Legacy v0.1 spellings remain valid and normalize to canonical modes: <code>ease-in</code> → <code>drive</code>, <code>ease-out</code> → <code>settle</code>, and <code>ease-in-out</code> → <code>settle</code>. New documents should use the canonical v0.2 names.</p>
 <hr>
 <h2>2. Joints</h2>
 <div class="table-wrap"><table><thead><tr><th>Group (plural)</th><th>Bones</th><th>Singular forms</th></tr></thead><tbody>
@@ -195,8 +205,8 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <p>&gt;  These are general literature values, not medical advice. Consult a &gt; qualified professional for physiotherapy or exercise prescription.</p>
 <hr>
 <h2>5. Rendering model</h2>
-<ol><li><strong>Forward kinematics</strong>: each phase sets joint angles; the renderer slerps</li></ol>
-<p>bone rotations between phases with the phase's easing.</p>
+<ol><li><strong>Forward kinematics</strong>: each phase sets joint angles; the renderer uses</li></ol>
+<p>C1-continuous quaternion splines between keyframes, shaped by the destination phase's timing mode.</p>
 <ol><li><strong>Grounding</strong>: the figure is dropped so its lowest point rests on the floor</li></ol>
 <p>(a bounding-box drop), which grounds standing, plank, and the lying/seated poses alike.</p>
 <ol><li><strong>Ground-lock IK</strong>: effectors listed in <code>ground-lock</code> (<code>hands</code>, <code>forearms</code>,</li></ol>
@@ -204,7 +214,7 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <ol><li><strong>Reach-IK</strong>: a <code>reach:</code> line drives an effector (`hand_left|hand_right|</li></ol>
 <p>foot_left|foot_right<code>, or the groups </code>hands<code>/</code>feet<code> for both sides) to a world <strong>target</strong> via Cyclic Coordinate Descent (CCD) over the arm/leg chain. A target is a body landmark bone (e.g. </code>ankle_left<code>), the keyword </code>floor<code>, or a prop anchor (</code>bar<code>, </code>seat<code>, </code>wall`). The solve is <strong>ROM-constrained</strong>: each iteration clamps every chain joint into its §4 Range-of-Motion limits (expressed as a per-axis box in the bone's local Euler frame), so a reach toward an unsafe or unreachable target settles on the closest *healthy* pose; solved angles obey the same hard limits as authored ones.</p>
 <ol><li><strong>Props</strong>: <code>prop chair|wall|bar|box|dip-bars</code> adds a scene object at a</li></ol>
-<p>fixed default placement (chair/wall behind, bar overhead, box in front, dip bars either side); its named anchors (<code>seat</code>, <code>wall</code>, <code>bar</code>, <code>box</code>, <code>bars</code>) become reach/pin targets.</p>
+<p>fixed default placement (chair/wall behind, bar overhead, box in front, dip bars either side); its named anchors (<code>seat</code>, <code>wall</code>, <code>bar</code>, <code>box</code>, <code>bars</code>) become reach/pin targets. Props are <strong>solid</strong>: each prop declares blocking faces (the wall's surface, the chair's backrest and seat edge, the box's near face) and a contact pass removes any body overlap — either by translating the whole figure out along the face normal (a wall-sit slides down the wall's *surface*, feet walking forward, instead of the torso hinging through the slab) or by bending the offending limb's hip clear, ROM-clamped like every other solve. Limbs pinned, gripped, or reached to a prop anchor are that phase's declared support and are exempt (a foot standing on the box top is not &quot;inside&quot; the box).</p>
 <ol><li><strong>Pins</strong>: <code>pin: &lt;effector&gt; &lt;anchor&gt;</code> translates the whole figure so the</li></ol>
 <p>effector sits on the anchor (effectors accept the same <code>hands</code>/<code>feet</code> groups as reach: <code>pin: hands bar</code> pins both). Where ground-lock keeps a foot on the floor and reach moves a limb to a target, a <strong>pin moves the body</strong> while the contact stays put, so the figure hangs from a bar, pulls up toward it, rises onto a box, or lowers into a dip as the joints work. Symmetric bar contacts resolve to side-specific anchors automatically (<code>bar.left</code> / <code>bar.right</code>, <code>bars.left</code> / <code>bars.right</code>). Contact post-processing also keeps floor-contacting soles level and gives bar-contacting wrists a stable overhand orientation; existing Posecode syntax remains unchanged.</p>
 <ol><li><strong>Spatial choreography</strong>: <code>turn: &lt;deg&gt;</code> rotates the figure's facing (yaw</li></ol>
@@ -213,12 +223,12 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
 <p>count surfaced to the UI.</p>
 <p>When a mocap clip is active, the renderer selects the take containing the most actual bone motion (rather than blindly choosing the longest embedded take), retargets and blends it, then restores solved terminal contacts on the visible character. Mocap therefore cannot overwrite a planted sole or pinned grip.</p>
 <p><strong>Start poses:</strong> <code>neutral</code>, <code>standing</code>, <code>plank</code>, <code>supine</code> (face-up), <code>prone</code> (face-down), <code>seated</code> (long-sit on the floor).</p>
-<p><strong>IK note:</strong> Three.js's bundled <code>CCDIKSolver</code> targets <code>SkinnedMesh</code>; the Posecode mannequin is rigid capsule segments, so Posecode implements CCD directly over the Object3D bone hierarchy (<code>posecode-render/ik.ts</code>) for both ground-lock and reach. Two-person/dual-IK and collision detection remain deferred (research §5.2, §6.2).</p>
+<p><strong>IK note:</strong> Three.js's bundled <code>CCDIKSolver</code> targets <code>SkinnedMesh</code>; the Posecode mannequin is rigid capsule segments, so Posecode implements CCD directly over the Object3D bone hierarchy (<code>posecode-render/ik.ts</code>) for both ground-lock and reach. Self-collision (limb-vs-body) and body-vs-prop contact are solved; two-person/ dual-IK and figure-vs-figure collision remain deferred (research §5.2, §6.2).</p>
 <hr>
 <h2>6. Intermediate Representation (IR)</h2>
 <p><code>parse(source)</code> returns <code>{ ir, warnings, errors }</code>. The IR is renderer-agnostic; angles are in <strong>degrees</strong>.</p>
 <pre class="code-block" data-lang="ts"><code>interface PosecodeIR {
-  version: string;          // &quot;0.1&quot;
+  version: string;          // &quot;0.2&quot;
   kind: string;             // &quot;exercise&quot; | &quot;stretch&quot; | &quot;posture&quot;
   name: string;
   rig: string;              // &quot;humanoid&quot;
@@ -227,7 +237,7 @@ DURATION   = NUMBER &quot;s&quot; ;                                (* e.g. 2s, 1
   phases: {
     name: string;
     durationSec: number;
-    easing: &quot;linear&quot; | &quot;ease-in&quot; | &quot;ease-out&quot; | &quot;ease-in-out&quot;;
+    easing: &quot;flow&quot; | &quot;settle&quot; | &quot;drive&quot; | &quot;snap&quot; | &quot;linear&quot;;
     targets: { boneId: string; euler: { x: number; y: number; z: number } }[];
     groundLock: string[];   // [&quot;hands&quot;,&quot;feet&quot;] or [&quot;foot_right&quot;]
     cue?: string;

--- a/playground/public/squat.posecode
+++ b/playground/public/squat.posecode
@@ -2,7 +2,7 @@ posecode exercise "Body-weight squat"
   rig humanoid
   pose start = standing
 
-  step "Descend" 1.6s ease-in-out:
+  step "Descend" 1.6s settle:
     hips: flex 80
     knees: flex 95
     ankles: dorsiflex 15
@@ -13,7 +13,7 @@ posecode exercise "Body-weight squat"
     ground-lock: feet
     cue "Sit the hips back, chest proud, knees track over the toes"
 
-  step "Drive up" 1.2s ease-out:
+  step "Drive up" 1.2s drive:
     hips: flex 0
     knees: flex 0
     ankles: plantarflex 0

--- a/playground/src/editor.ts
+++ b/playground/src/editor.ts
@@ -75,6 +75,10 @@ const ACTIONS = new Set([
   "plantarflex",
 ]);
 const ATOMS = new Set([
+  "flow",
+  "settle",
+  "drive",
+  "snap",
   "linear",
   "ease-in",
   "ease-out",

--- a/scripts/generate-content-pages.mjs
+++ b/scripts/generate-content-pages.mjs
@@ -62,7 +62,11 @@ function slugTitle(label) {
 }
 
 async function main() {
-  const server = await createServer({ root: playgroundRoot, server: { middlewareMode: true } });
+  const server = await createServer({
+    root: playgroundRoot,
+    appType: "custom",
+    server: { middlewareMode: true, hmr: false, ws: false },
+  });
   let PRESETS;
   try {
     ({ PRESETS } = await server.ssrLoadModule("/src/presets.ts"));
@@ -199,7 +203,7 @@ ${stepsHtml}
   const specHtml = pageShell({
     title: "Posecode Language Specification: The .posecode Kinematic Motion DSL",
     description:
-      "The full Posecode v0.1 grammar, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure.",
+      "The full Posecode v0.2 grammar, timing modes, joints, actions, and range-of-motion tables: a small text language LLMs write to describe human movement as an animated 3D figure.",
     canonicalPath: "/spec.html",
     bodyHtml: `<p class="eyebrow">Reference</p>\n${renderMarkdown(specMd)}`,
   });

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,4 +1,4 @@
-# Posecode Protocol Specification v0.1
+# Posecode Protocol Specification v0.2
 
 Posecode is a small text language for describing a single person's **kinematic
 movement** so it can be rendered as an animated 3D figure in a web browser.
@@ -8,7 +8,8 @@ a compact, readable document; a client-side parser + renderer turns it into a
 moving mannequin. The model never produces 3D matrices: it expresses the
 *semantic phases* of a movement, which it already understands.
 
-- **Version keyword:** documents declare nothing; this is `posecode 0.1`.
+- **Version keyword:** documents declare nothing; this is `posecode 0.2`.
+- **Compatibility:** v0.2 parsers continue to accept the v0.1 easing aliases.
 - **File extension:** `.posecode`
 - **Compute model:** generation is pure text (server-cheap); all 3D math runs
   on the client (Three.js). See the project research §6.
@@ -29,8 +30,8 @@ prop       = "prop" WORD ;                              (* chair|wall|bar|box|di
 pose       = "pose" "start" "=" WORD ;                  (* neutral|standing|plank|supine|prone|seated *)
 clip       = "clip" STRING ;                            (* optional mocap clip; renderer may retarget & blend *)
 repeat     = "repeat" NUMBER ;
-step       = "step" STRING DURATION easing ":" { child } ;
-easing     = "linear" | "ease-in" | "ease-out" | "ease-in-out" ;
+step       = "step" STRING DURATION timingMode ":" { child } ;
+timingMode = "flow" | "settle" | "drive" | "snap" | "linear" ;
 child      = jointTarget | groundLock | reach | pin | turn | travel | cue ;
 jointTarget= joint ":" action [ NUMBER ] ;
 groundLock = "ground-lock" ":" effector { "," effector } ;
@@ -44,6 +45,25 @@ DURATION   = NUMBER "s" ;                                (* e.g. 2s, 1.5s *)
 
 A `step` is one **phase** of the movement. Phases run in sequence; within a
 phase, all joint targets apply concurrently.
+
+Ground locks accept the groups `hands`, `forearms`, and `feet`, plus the
+single-side forms `hand_left|hand_right`, `elbow_left|elbow_right`, and
+`foot_left|foot_right`. Human-readable `left foot`, `right foot`, `left hand`,
+and related forms normalize to the canonical side-specific names.
+
+Timing modes describe how motion crosses the phase boundary:
+
+| Mode | Use |
+| --- | --- |
+| `flow` | Carry velocity smoothly through the pose. |
+| `settle` | Decelerate into a deliberate rest. |
+| `drive` | Accelerate out of rest. |
+| `snap` | Arrive quickly and stop sharply. |
+| `linear` | Even timing without a shaped acceleration curve. |
+
+Legacy v0.1 spellings remain valid and normalize to canonical modes:
+`ease-in` → `drive`, `ease-out` → `settle`, and `ease-in-out` → `settle`.
+New documents should use the canonical v0.2 names.
 
 ---
 
@@ -119,8 +139,9 @@ research §5.1 normative tables. Selected ceilings (degrees):
 
 ## 5. Rendering model
 
-1. **Forward kinematics**: each phase sets joint angles; the renderer slerps
-   bone rotations between phases with the phase's easing.
+1. **Forward kinematics**: each phase sets joint angles; the renderer uses
+   C1-continuous quaternion splines between keyframes, shaped by the destination
+   phase's timing mode.
 2. **Grounding**: the figure is dropped so its lowest point rests on the floor
    (a bounding-box drop), which grounds standing, plank, and the lying/seated
    poses alike.
@@ -194,7 +215,7 @@ angles are in **degrees**.
 
 ```ts
 interface PosecodeIR {
-  version: string;          // "0.1"
+  version: string;          // "0.2"
   kind: string;             // "exercise" | "stretch" | "posture"
   name: string;
   rig: string;              // "humanoid"
@@ -203,7 +224,7 @@ interface PosecodeIR {
   phases: {
     name: string;
     durationSec: number;
-    easing: "linear" | "ease-in" | "ease-out" | "ease-in-out";
+    easing: "flow" | "settle" | "drive" | "snap" | "linear";
     targets: { boneId: string; euler: { x: number; y: number; z: number } }[];
     groundLock: string[];   // ["hands","feet"] or ["foot_right"]
     cue?: string;

--- a/spec/llm-authoring.md
+++ b/spec/llm-authoring.md
@@ -17,10 +17,10 @@ posecode <kind> "<Name>"          # kind = exercise | stretch | posture
   rig humanoid
   prop <type>                  # optional: chair | wall | bar | box | dip-bars (repeatable)
   pose start = <pose>          # neutral | standing | plank | supine | prone | seated
-  step "<Phase name>" <Ns> <easing>:   # easing = linear | ease-in | ease-out | ease-in-out
+  step "<Phase name>" <Ns> <mode>:     # mode = flow | settle | drive | snap | linear
     <joint>: <action> <degrees>
     reach: <effector> <target> # optional: drive a hand/foot to a target via IK
-    ground-lock: <effectors>   # groups (hands/forearms/feet) or per-side aliases such as foot_right
+    ground-lock: <effectors>   # groups, foot_left/foot_right, or natural left foot/right foot
     turn: <degrees>            # optional: face this yaw by phase end (standing only)
     travel: <x> <z>            # optional: move to this x z (metres) by phase end
     cue "<short coaching cue>"
@@ -57,6 +57,19 @@ wrists hips knees ankles`. Plural names move both sides symmetrically; use
    floor (feet when standing; hands and feet in a plank).
 5. `repeat` the rep count.
 
+## Timing modes
+
+- `flow`: carry momentum through an interior pose; use for continuous dance,
+  locomotion, and multi-part sports motion.
+- `settle`: decelerate into a real rest; use at a squat bottom, landing, hold,
+  or final pose.
+- `drive`: accelerate from rest; use for a jump, push, lift, or recoil.
+- `snap`: arrive quickly and stop sharply; use for a strike or release.
+- `linear`: constant timing; best for deliberate holds or mechanical motion.
+
+The older names `ease-in`, `ease-out`, and `ease-in-out` still parse for
+compatibility, but do not author new documents with them.
+
 ## Example
 
 ```posecode
@@ -64,14 +77,14 @@ posecode exercise "Body-weight squat"
   rig humanoid
   pose start = standing
 
-  step "Descend" 1.6s ease-in-out:
+  step "Descend" 1.6s settle:
     hips: flex 80
     knees: flex 95
     ankles: dorsiflex 14
     ground-lock: feet
     cue "Sit the hips back, chest proud, knees track over the toes"
 
-  step "Drive up" 1.2s ease-out:
+  step "Drive up" 1.2s drive:
     hips: flex 0
     knees: flex 0
     ankles: dorsiflex 0
@@ -91,14 +104,14 @@ posecode exercise "Deadlift"
   rig humanoid
   pose start = standing
 
-  step "Lower" 1.8s ease-in-out:
+  step "Lower" 1.8s settle:
     pelvis: hinge 95
     knees: flex 25
     shoulders: flex 90
     ground-lock: feet
     cue "Hips back, flat back: let the arms hang to the bar"
 
-  step "Lift" 1.4s ease-out:
+  step "Lift" 1.4s drive:
     pelvis: hinge 0
     knees: flex 0
     shoulders: flex 0
@@ -120,7 +133,7 @@ posecode exercise "Deadlift"
   let `reach` finish the hand placement. Example, touch your toes:
 
   ```posecode
-  step "Fold" 2.5s ease-in-out:
+  step "Fold" 2.5s settle:
     pelvis: hinge 95
     knees: flex 12
     reach: hand_left ankle_left
@@ -155,8 +168,8 @@ The same grammar covers many fields. A few patterns that read well:
   leg stays planted.
 - **Desk / posture**: slow `stretch` documents with `ground-lock: feet`;
   contrast a "collapsed" phase with a "tall" reset.
-- **Sports / martial arts**: short, snappy phases (0.3–0.6s) with `ease-out`
-  on the strike; chamber → extend → re-chamber → return.
+- **Sports / martial arts**: short phases (0.2–0.6s); use `flow` through a
+  gather/chamber, `drive` for takeoff, and `snap` on the strike or release.
 
 ### Dance / choreography
 


### PR DESCRIPTION
## What

- define the Posecode 0.2 timing vocabulary, including `drive`, `settle`, `flow`, and `snap`, while preserving legacy easing aliases
- add a parser validation CLI with recursive, strict, and JSON modes
- expose embed compatibility metadata and structured ready/error events
- support canonical and human-readable per-side ground locks such as `foot_left` and `left foot`
- harden inline custom-element startup and reduce cascading parser diagnostics
- update package versions, generated documentation, examples, editor completions, CI, and integration guidance

## Why

A third-party basketball site authored movements with the current Posecode vocabulary but loaded `posecode-embed@0.1.0`. Its cards failed on modes such as `drive`, and consumer-facing compatibility/version checks were not available. This release makes that mismatch visible, validates assets before deployment, and supports the single-foot contacts used by sports movements.

## Impact

Consumers can pin compatible parser/embed versions, validate complete movement libraries in CI, listen for machine-readable embed state, and author basketball-style phases with natural timing and contact language.

## Verification

- `npm run typecheck`
- `npm test -- --run` — 268 tests passed
- `npm run build:packages`
- `npm run build`
- `npm run eval` — 1,049/1,049 checks across 73 movements; zero parse failures and zero clamp warnings
- npm publish dry-runs for parser, renderer, and embed
- browser smoke test of the built 0.2 embed bundle with `drive`, `settle`, `snap`, travel, and `ground-lock: left foot`
