### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/fresh-poses-ship.md
+++ b/.changeset/fresh-poses-ship.md
@@ -1,5 +1,0 @@
----
-"posecode-mcp": patch
----
-
-Ship the current authoring guide with the MCP npm package and prepare all public packages for automated releases.

--- a/packages/posecode-embed/CHANGELOG.md
+++ b/packages/posecode-embed/CHANGELOG.md
@@ -1,0 +1,9 @@
+# posecode-embed
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-parser@0.2.1
+- posecode-render@0.2.1
+- posecode-share@0.2.1

--- a/packages/posecode-embed/package.json
+++ b/packages/posecode-embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "posecode-embed",
-  "version": "0.2.0",
-  "description": "Embed a live 3D Posecode movement anywhere with one <script> tag \u2014 the <posecode-player> web component.",
+  "version": "0.2.1",
+  "description": "Embed a live 3D Posecode movement anywhere with one <script> tag — the <posecode-player> web component.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -36,9 +36,9 @@
     "three.js"
   ],
   "dependencies": {
-    "posecode-parser": "0.2.0",
-    "posecode-render": "0.2.0",
-    "posecode-share": "0.2.0"
+    "posecode-parser": "0.2.1",
+    "posecode-render": "0.2.1",
+    "posecode-share": "0.2.1"
   },
   "devDependencies": {
     "esbuild": "^0.28.1"

--- a/packages/posecode-embed/src/compat.ts
+++ b/packages/posecode-embed/src/compat.ts
@@ -4,7 +4,7 @@ import { parse, POSECODE_VERSION } from "posecode-parser";
 import type { ParseResult } from "posecode-parser";
 
 /** Version of the posecode-embed package/bundle. */
-export const version = "0.2.0";
+export const version = "0.2.1";
 
 /** Version of the Posecode language understood by this bundle. */
 export const languageVersion = POSECODE_VERSION;

--- a/packages/posecode-eval/CHANGELOG.md
+++ b/packages/posecode-eval/CHANGELOG.md
@@ -1,0 +1,8 @@
+# posecode-eval
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-parser@0.2.1
+- posecode-render@0.2.1

--- a/packages/posecode-eval/package.json
+++ b/packages/posecode-eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-eval",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Fidelity eval harness for Posecode: headless kinematic probing + geometric invariant scoring.",
   "license": "MIT",
@@ -11,8 +11,8 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "posecode-parser": "0.2.0",
-    "posecode-render": "0.2.0",
+    "posecode-parser": "0.2.1",
+    "posecode-render": "0.2.1",
     "three": "^0.171.0"
   },
   "devDependencies": {

--- a/packages/posecode-language/CHANGELOG.md
+++ b/packages/posecode-language/CHANGELOG.md
@@ -1,0 +1,7 @@
+# posecode-language
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-parser@0.2.1

--- a/packages/posecode-language/package.json
+++ b/packages/posecode-language/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-language",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Editor language service for .posecode: diagnostics, completions, and hovers built on posecode-parser. Powers both the playground editor and the LSP.",
   "license": "MIT",
@@ -11,6 +11,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "posecode-parser": "0.2.0"
+    "posecode-parser": "0.2.1"
   }
 }

--- a/packages/posecode-lsp/CHANGELOG.md
+++ b/packages/posecode-lsp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# posecode-lsp
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-language@0.2.1

--- a/packages/posecode-lsp/package.json
+++ b/packages/posecode-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-lsp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Language Server Protocol implementation for the Posecode (.posecode) DSL: diagnostics, completion, and hover, powered by posecode-language.",
   "license": "MIT",
@@ -16,7 +16,7 @@
     "start": "tsx src/server.ts"
   },
   "dependencies": {
-    "posecode-language": "0.2.0",
+    "posecode-language": "0.2.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/packages/posecode-mcp/CHANGELOG.md
+++ b/packages/posecode-mcp/CHANGELOG.md
@@ -1,0 +1,9 @@
+# posecode-mcp
+
+## 0.2.1
+
+### Patch Changes
+
+- 60403fd: Ship the current authoring guide with the MCP npm package and prepare all public packages for automated releases.
+  - posecode-parser@0.2.1
+  - posecode-share@0.2.1

--- a/packages/posecode-mcp/package.json
+++ b/packages/posecode-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Model Context Protocol server for Posecode: let any LLM agent validate, ROM-check, and get a render link for a .posecode movement, natively.",
   "mcpName": "io.github.posecode-dev/posecode-mcp",
   "license": "MIT",
@@ -44,8 +44,8 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "posecode-parser": "0.2.0",
-    "posecode-share": "0.2.0",
+    "posecode-parser": "0.2.1",
+    "posecode-share": "0.2.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/posecode-mcp/server.json
+++ b/packages/posecode-mcp/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/posecode-dev/posecode",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "posecode-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/posecode-parser/CHANGELOG.md
+++ b/packages/posecode-parser/CHANGELOG.md
@@ -1,0 +1,3 @@
+# posecode-parser
+
+## 0.2.1

--- a/packages/posecode-parser/package.json
+++ b/packages/posecode-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-parser",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Parse the .posecode kinematic motion DSL into a validated, ROM-clamped intermediate representation.",
   "license": "MIT",
   "type": "module",

--- a/packages/posecode-render/CHANGELOG.md
+++ b/packages/posecode-render/CHANGELOG.md
@@ -1,0 +1,7 @@
+# posecode-render
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-parser@0.2.1

--- a/packages/posecode-render/package.json
+++ b/packages/posecode-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-render",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Render a Posecode IR as an animated 3D human figure (skinned character or procedural mannequin) with Three.js.",
   "license": "MIT",
   "type": "module",
@@ -17,7 +17,7 @@
     "three": "^0.171.0"
   },
   "peerDependencies": {
-    "posecode-parser": "0.2.0"
+    "posecode-parser": "0.2.1"
   },
   "devDependencies": {
     "@types/three": "^0.171.0"

--- a/packages/posecode-share/CHANGELOG.md
+++ b/packages/posecode-share/CHANGELOG.md
@@ -1,0 +1,3 @@
+# posecode-share
+
+## 0.2.1

--- a/packages/posecode-share/package.json
+++ b/packages/posecode-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "posecode-share",
-  "version": "0.2.0",
-  "description": "Encode/decode .posecode documents to URL-safe share tokens \u2014 the distribution primitive for Posecode permalinks and embeds.",
+  "version": "0.2.1",
+  "description": "Encode/decode .posecode documents to URL-safe share tokens — the distribution primitive for Posecode permalinks and embeds.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/playground/CHANGELOG.md
+++ b/playground/CHANGELOG.md
@@ -1,0 +1,10 @@
+# posecode-playground
+
+## 0.2.1
+
+### Patch Changes
+
+- posecode-parser@0.2.1
+- posecode-render@0.2.1
+- posecode-share@0.2.1
+- posecode-language@0.2.1

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posecode-playground",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -17,10 +17,10 @@
     "@codemirror/view": "^6.36.1",
     "@lezer/highlight": "^1.2.1",
     "@vercel/analytics": "^2.0.1",
-    "posecode-language": "0.2.0",
-    "posecode-parser": "0.2.0",
-    "posecode-render": "0.2.0",
-    "posecode-share": "0.2.0",
+    "posecode-language": "0.2.1",
+    "posecode-parser": "0.2.1",
+    "posecode-render": "0.2.1",
+    "posecode-share": "0.2.1",
     "three": "^0.171.0"
   },
   "devDependencies": {

--- a/scripts/sync-mcp-version.mjs
+++ b/scripts/sync-mcp-version.mjs
@@ -1,10 +1,14 @@
 import { readFileSync, writeFileSync } from "node:fs";
 
-const packagePath = new URL("../packages/posecode-mcp/package.json", import.meta.url);
+const mcpPackagePath = new URL("../packages/posecode-mcp/package.json", import.meta.url);
 const serverPath = new URL("../packages/posecode-mcp/server.json", import.meta.url);
+const embedPackagePath = new URL("../packages/posecode-embed/package.json", import.meta.url);
+const embedSourcePath = new URL("../packages/posecode-embed/src/compat.ts", import.meta.url);
 
-const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+const packageJson = JSON.parse(readFileSync(mcpPackagePath, "utf8"));
 const serverJson = JSON.parse(readFileSync(serverPath, "utf8"));
+const embedPackageJson = JSON.parse(readFileSync(embedPackagePath, "utf8"));
+const embedSource = readFileSync(embedSourcePath, "utf8");
 
 serverJson.version = packageJson.version;
 for (const pkg of serverJson.packages ?? []) {
@@ -14,4 +18,20 @@ for (const pkg of serverJson.packages ?? []) {
 }
 
 writeFileSync(serverPath, `${JSON.stringify(serverJson, null, 2)}\n`);
-console.log(`Synced MCP Registry metadata to ${packageJson.name}@${packageJson.version}.`);
+
+const versionDeclaration = /export const version = "[^"]+";/;
+if (!versionDeclaration.test(embedSource)) {
+  throw new Error("Could not find the exported posecode-embed version declaration.");
+}
+writeFileSync(
+  embedSourcePath,
+  embedSource.replace(
+    versionDeclaration,
+    `export const version = ${JSON.stringify(embedPackageJson.version)};`,
+  ),
+);
+
+console.log(
+  `Synced release metadata to ${packageJson.name}@${packageJson.version} and ` +
+    `${embedPackageJson.name}@${embedPackageJson.version}.`,
+);


### PR DESCRIPTION
## Release PoseCode 0.2.1

This PR was generated by Changesets after merging the npm and MCP release automation.

It synchronizes the five public packages at version `0.2.1`:

- `posecode-parser`
- `posecode-render`
- `posecode-share`
- `posecode-embed`
- `posecode-mcp`

It also updates internal workspace dependency versions, package changelogs, and `packages/posecode-mcp/server.json`.

## Before merging

Configure npm Trusted Publishing for all five packages with:

- Provider: GitHub Actions
- Organization: `posecode-dev`
- Repository: `posecode`
- Workflow filename: `release.yml`
- Allowed action: npm publish

Merging this PR triggers the release workflow, which publishes the npm packages and then updates the official MCP Registry.
