### PR TITLE
Hide source button on mobile

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1471,8 +1471,7 @@ select:hover {
     justify-content: center;
   }
   #share {
-    grid-column: 1 / 3;
-    grid-row: 2;
+    display: none;
   }
   #feedback {
     grid-column: 3;


### PR DESCRIPTION
## What changed

- Hide the Source/share button at mobile widths.
- Keep the existing GitHub button and desktop sharing control unchanged.

## Why

The wide Source control made the mobile header feel crowded and duplicated access already represented by the GitHub action.

## Impact

Mobile users get a cleaner header. Desktop behavior is unchanged.

## Validation

- `npm run build`
- `git diff --check`
