### PR TITLE
Move source link out of playground

### DIFF
--- a/playground/play.html
+++ b/playground/play.html
@@ -101,16 +101,6 @@
         >
           <span class="ico-github" aria-hidden="true"></span><span class="lbl">GitHub</span>
         </a>
-        <a
-          href="https://github.com/posecode-dev/posecode/blob/main/LICENSING.md"
-          class="btn ghost"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="View source code and licensing"
-          title="View source code and licensing"
-        >
-          <span class="lbl">Source</span>
-        </a>
         <button
           id="share"
           class="btn ghost"


### PR DESCRIPTION
## What changed

- Remove the redundant Source button from the playground header at all viewport sizes.
- Keep the existing Source link in the landing-page footer as the repository entry point.

## Why

The desktop header already includes a GitHub action, so a neighboring Source button made the action group feel repetitive. Source and licensing links fit better in the landing-page footer.

## Impact

The playground header is less crowded on desktop and mobile. The landing page continues to expose both Source and Licensing links.

## Validation

- `npm run build`
- `git diff --check`
