### PR TITLE
Tighten mobile header layout

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1487,7 +1487,11 @@ select:hover {
     content: "Copy link";
     font-size: 13px;
   }
-  #copy-prompt { grid-column: 1 / -1; min-height: 42px; }
+  #copy-prompt {
+    grid-column: 1 / 3;
+    grid-row: 2;
+    min-height: 42px;
+  }
   .intro { padding-left: 12px; padding-right: 12px; }
   .layout { grid-template-columns: 1fr; }
   .transport { gap: 8px; padding-left: 12px; padding-right: 12px; }


### PR DESCRIPTION
## What changed

- Keep the mobile playground controls to two rows.
- Place Copy LLM prompt beside the GitHub action on the second row.
- Preserve the existing first row and desktop layout.

## Why

Removing the Source button left an empty area in the second mobile grid row and pushed the primary prompt action onto an unnecessary third row.

## Impact

The mobile header is shorter, balanced, and uses the available width without a large gap.

## Validation

- Verified visually at a 390 × 844 mobile viewport.
- Confirmed both rows align at 42px and Share remains hidden.
- `npm run build`
- `git diff --check`
