### PR TITLE
Place Dance after Performance

### DIFF
--- a/playground/public/moves/index.html
+++ b/playground/public/moves/index.html
@@ -187,6 +187,44 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
       </div>
 
       <div class="domain-group">
+        <h2>Dance</h2>
+        <div class="move-grid">
+          <a class="move-card" href="/moves/demi-plie.html">
+                <span class="mc-name">Demi-plié</span>
+                <span class="mc-meta">Quadriceps · Body weight · Beginner</span>
+              </a>
+<a class="move-card" href="/moves/releve.html">
+                <span class="mc-name">Relevé</span>
+                <span class="mc-meta">Calves · Body weight · Beginner</span>
+              </a>
+<a class="move-card" href="/moves/tendu.html">
+                <span class="mc-name">Tendu</span>
+                <span class="mc-meta">Hip flexors · Body weight · Intermediate</span>
+              </a>
+<a class="move-card" href="/moves/pirouette.html">
+                <span class="mc-name">Pirouette (full turn)</span>
+                <span class="mc-meta">Full body · Body weight · Intermediate</span>
+              </a>
+<a class="move-card" href="/moves/box-step.html">
+                <span class="mc-name">Box step (travels)</span>
+                <span class="mc-meta">Full body · Body weight · Beginner</span>
+              </a>
+<a class="move-card" href="/moves/grapevine.html">
+                <span class="mc-name">Grapevine (travels)</span>
+                <span class="mc-meta">Full body · Body weight · Beginner</span>
+              </a>
+<a class="move-card" href="/moves/waltz-box.html">
+                <span class="mc-name">Waltz box step</span>
+                <span class="mc-meta">Full body · Body weight · Beginner</span>
+              </a>
+<a class="move-card" href="/moves/chasse.html">
+                <span class="mc-name">Chassé (travels)</span>
+                <span class="mc-meta">Full body · Body weight · Intermediate</span>
+              </a>
+        </div>
+      </div>
+
+      <div class="domain-group">
         <h2>Martial arts</h2>
         <div class="move-grid">
           <a class="move-card" href="/moves/front-kick.html">
@@ -316,44 +354,6 @@ footer.site-footer p{font-size:12.5px;color:var(--muted);margin:0 0 6px;max-widt
 <a class="move-card" href="/moves/spine-rotation.html">
                 <span class="mc-name">Spine rotation (ROM)</span>
                 <span class="mc-meta">Obliques · Body weight · Beginner</span>
-              </a>
-        </div>
-      </div>
-
-      <div class="domain-group">
-        <h2>Dance</h2>
-        <div class="move-grid">
-          <a class="move-card" href="/moves/demi-plie.html">
-                <span class="mc-name">Demi-plié</span>
-                <span class="mc-meta">Quadriceps · Body weight · Beginner</span>
-              </a>
-<a class="move-card" href="/moves/releve.html">
-                <span class="mc-name">Relevé</span>
-                <span class="mc-meta">Calves · Body weight · Beginner</span>
-              </a>
-<a class="move-card" href="/moves/tendu.html">
-                <span class="mc-name">Tendu</span>
-                <span class="mc-meta">Hip flexors · Body weight · Intermediate</span>
-              </a>
-<a class="move-card" href="/moves/pirouette.html">
-                <span class="mc-name">Pirouette (full turn)</span>
-                <span class="mc-meta">Full body · Body weight · Intermediate</span>
-              </a>
-<a class="move-card" href="/moves/box-step.html">
-                <span class="mc-name">Box step (travels)</span>
-                <span class="mc-meta">Full body · Body weight · Beginner</span>
-              </a>
-<a class="move-card" href="/moves/grapevine.html">
-                <span class="mc-name">Grapevine (travels)</span>
-                <span class="mc-meta">Full body · Body weight · Beginner</span>
-              </a>
-<a class="move-card" href="/moves/waltz-box.html">
-                <span class="mc-name">Waltz box step</span>
-                <span class="mc-meta">Full body · Body weight · Beginner</span>
-              </a>
-<a class="move-card" href="/moves/chasse.html">
-                <span class="mc-name">Chassé (travels)</span>
-                <span class="mc-meta">Full body · Body weight · Intermediate</span>
               </a>
         </div>
       </div>

--- a/playground/public/sitemap.xml
+++ b/playground/public/sitemap.xml
@@ -43,6 +43,12 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://www.posecode.org/moves/demi-plie.html</loc>
+    <lastmod>2026-07-17</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://www.posecode.org/moves/deadlift.html</loc>
     <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
@@ -194,12 +200,6 @@
   </url>
   <url>
     <loc>https://www.posecode.org/moves/high-knee-march.html</loc>
-    <lastmod>2026-07-17</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://www.posecode.org/moves/demi-plie.html</loc>
     <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>

--- a/playground/src/presets.ts
+++ b/playground/src/presets.ts
@@ -129,6 +129,9 @@ export const PRESETS: Preset[] = [
   { id: "squat", label: "Body-weight squat", domain: "Fitness", bodyPart: "Upper legs", target: "Quadriceps", equipment: "Body weight", difficulty: "Beginner", status: "ready", source: squat },
   { id: "superhero-landing", label: "Superhero three-point landing", domain: "Performance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Advanced", status: "ready", source: superheroLanding },
   { id: "dance-phrase", label: "Dance phrase (8-count)", domain: "Dance", bodyPart: "Full body", target: "Full body", equipment: "Body weight", difficulty: "Intermediate", status: "experimental", source: dancePhrase },
+  // Keep one ready Dance entry here so first-seen domain grouping places Dance
+  // immediately after Performance even when experimental previews are hidden.
+  { id: "demi-plie", label: "Demi-plié", domain: "Dance", bodyPart: "Upper legs", target: "Quadriceps", equipment: "Body weight", difficulty: "Beginner", status: "ready", source: demiPlie },
   { id: "deadlift", label: "Deadlift (hip hinge)", domain: "Fitness", bodyPart: "Back", target: "Hamstrings & glutes", equipment: "Body weight", difficulty: "Intermediate", status: "ready", source: deadlift },
   { id: "shoulder-abduction", label: "Shoulder abduction (ROM)", domain: "Education", bodyPart: "Shoulders", target: "Deltoids", equipment: "Body weight", difficulty: "Beginner", status: "experimental", source: shoulderAbduction },
   { id: "front-kick", label: "Front kick", domain: "Martial arts", bodyPart: "Upper legs", target: "Hip flexors", equipment: "Body weight", difficulty: "Intermediate", status: "ready", source: frontKick },
@@ -179,7 +182,6 @@ export const PRESETS: Preset[] = [
   { id: "high-knee-march", label: "High-knee march", domain: "Warm-up", bodyPart: "Full body", target: "Hip flexors", equipment: "Body weight", difficulty: "Beginner", status: "ready", source: highKneeMarch },
 
   // --- Dance / choreography (flagship) ---
-  { id: "demi-plie", label: "Demi-plié", domain: "Dance", bodyPart: "Upper legs", target: "Quadriceps", equipment: "Body weight", difficulty: "Beginner", status: "ready", source: demiPlie },
   { id: "releve", label: "Relevé", domain: "Dance", bodyPart: "Lower legs", target: "Calves", equipment: "Body weight", difficulty: "Beginner", status: "ready", source: releve },
   { id: "tendu", label: "Tendu", domain: "Dance", bodyPart: "Upper legs", target: "Hip flexors", equipment: "Body weight", difficulty: "Intermediate", status: "ready", source: tendu },
   { id: "port-de-bras", label: "Port de bras", domain: "Dance", bodyPart: "Shoulders", target: "Deltoids", equipment: "Body weight", difficulty: "Beginner", status: "experimental", source: portDeBras },

--- a/playground/test/library-order.test.ts
+++ b/playground/test/library-order.test.ts
@@ -3,6 +3,7 @@ import {
   FEATURED_LIBRARY_MOVEMENT_ID,
   prioritizeFeaturedMovement,
 } from "../src/library-order.js";
+import { PRESETS } from "../src/presets.js";
 
 describe("movement library ordering", () => {
   it("promotes Jumping jacks ahead of otherwise stable results", () => {
@@ -28,5 +29,15 @@ describe("movement library ordering", () => {
     const movements = [{ id: "squat" }, { id: "deadlift" }];
 
     expect(prioritizeFeaturedMovement(movements)).toEqual(movements);
+  });
+
+  it("places the ready Dance category immediately after Performance", () => {
+    const readyDomains = [
+      ...new Set(PRESETS.filter((preset) => preset.status === "ready").map((preset) => preset.domain)),
+    ];
+    const performanceIndex = readyDomains.indexOf("Performance");
+
+    expect(performanceIndex).toBeGreaterThanOrEqual(0);
+    expect(readyDomains[performanceIndex + 1]).toBe("Dance");
   });
 });


### PR DESCRIPTION
## What changed

- Place the first ready Dance movement immediately after Performance in the preset catalog.
- Regenerate the static movement index and sitemap in the same order.
- Add a regression test for the ready-only category sequence.

## Why

The early Dance phrase is experimental. When the default ready-only filter hid it, first-seen grouping did not encounter Dance until much later, so the Dance category appeared far below Performance.

## Impact

Performance is now followed immediately by Dance in both the playground movement library and the static movement index.

## Validation

- `npx vitest run playground/test/library-order.test.ts`
- `npm run build`
- Confirmed generated headings render Fitness, Performance, Dance, then Education.
- `git diff --check`
