### PR TITLE
Playground: hide motion-export buttons on mobile

### DIFF
--- a/playground/play.html
+++ b/playground/play.html
@@ -119,22 +119,24 @@
           <span class="ico-link" aria-hidden="true"></span
           ><span class="lbl" aria-live="polite">Share</span>
         </button>
-        <button
-          id="download-bvh"
-          class="btn ghost"
-          aria-label="Download BVH"
-          title="Download the movement as a .bvh motion file for Blender and other tools"
-        >
-          <span class="lbl" aria-live="polite">Download BVH</span>
-        </button>
-        <button
-          id="download-gltf"
-          class="btn ghost"
-          aria-label="Download glTF"
-          title="Download the movement as a .glb glTF asset (rig + animation) for Three.js and web pipelines"
-        >
-          <span class="lbl" aria-live="polite">Download glTF</span>
-        </button>
+        <div class="tb-downloads">
+          <button
+            id="download-bvh"
+            class="btn ghost"
+            aria-label="Download BVH"
+            title="Download the movement as a .bvh motion file for Blender and other tools"
+          >
+            <span class="lbl" aria-live="polite">Download BVH</span>
+          </button>
+          <button
+            id="download-gltf"
+            class="btn ghost"
+            aria-label="Download glTF"
+            title="Download the movement as a .glb glTF asset (rig + animation) for Three.js and web pipelines"
+          >
+            <span class="lbl" aria-live="polite">Download glTF</span>
+          </button>
+        </div>
         <button
           id="copy-prompt"
           class="btn primary"

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -1607,19 +1607,12 @@ select:hover {
     grid-row: 2;
     min-height: 42px;
   }
-  /* Motion-export buttons: one full-width row, split into two equal halves so
-     they read as a balanced pair instead of hugging the left of the grid. */
+  /* Motion export (BVH / glTF) is a desktop-pipeline action — a downloaded
+     .bvh/.glb is only useful in Blender, a Three.js project, or a game engine,
+     none of which live on the phone. Hide it on mobile to keep the toolbar to
+     the two rows that matter (movement + primary CTA); it stays on desktop. */
   .tb-downloads {
-    display: flex;
-    grid-column: 1 / -1;
-    grid-row: 3;
-    gap: 6px;
-  }
-  .tb-downloads > .btn {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: 42px;
-    justify-content: center;
+    display: none;
   }
   .intro { padding-left: 12px; padding-right: 12px; }
   .layout { grid-template-columns: 1fr; }

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -301,6 +301,14 @@ select:hover {
   align-items: center;
 }
 
+/* The two motion-export buttons are grouped so mobile can lay them out as one
+   balanced row. On desktop the wrapper is transparent (`display: contents`),
+   so the buttons stay direct children of the flex toolbar and the desktop row
+   is unchanged. */
+.tb-downloads {
+  display: contents;
+}
+
 /* Movement-library trigger — the one content control in the topbar. Reads like
    a select (kicker, current movement, caret) but opens the full browse panel. */
 .lib-btn {
@@ -1598,6 +1606,20 @@ select:hover {
     grid-column: 1 / 4;
     grid-row: 2;
     min-height: 42px;
+  }
+  /* Motion-export buttons: one full-width row, split into two equal halves so
+     they read as a balanced pair instead of hugging the left of the grid. */
+  .tb-downloads {
+    display: flex;
+    grid-column: 1 / -1;
+    grid-row: 3;
+    gap: 6px;
+  }
+  .tb-downloads > .btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 42px;
+    justify-content: center;
   }
   .intro { padding-left: 12px; padding-right: 12px; }
   .layout { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Description

The two motion-export buttons (**Download BVH** / **Download glTF**, added in #108) cluttered the mobile toolbar and — more importantly — have no real audience on a phone. A downloaded `.bvh`/`.glb` is only useful in a desktop pipeline (Blender, a Three.js project, a game engine), none of which run on the device you'd be holding.

So this keeps them on **desktop** and hides them on **mobile**:

- The two buttons are grouped in a `.tb-downloads` wrapper.
- Desktop: `display: contents` — the wrapper is transparent, so the desktop flex toolbar is unchanged and still shows both buttons.
- Mobile (≤860px): `display: none` — removes the whole third toolbar row, leaving the two rows that matter (movement picker + primary CTA).

No design-language changes — same buttons, colours, radius, and typography; just fewer, better-targeted controls on small screens.

Verified with the pre-installed Chromium: mobile (360/390px) now shows a clean two-row toolbar with no export row; desktop (1280px) is unchanged and still shows Download BVH / glTF.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Movement/Preset addition (adding a new `.posecode` script and registering it)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my own code
- My changes generate no new TypeScript/compiler warnings or errors:
  - [x] Running `npm run typecheck` passes successfully
  - [x] Running `npm run build` compiles without errors
- [x] I have run the unit test suite (`npm test`) and all tests pass
- [ ] If applicable, I have run the fidelity evals (`npm run eval`) and all checks pass — n/a (CSS/markup only)
- [ ] If I added a new movement, I ran `node scripts/generate-content-pages.mjs` to regenerate the static pages — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)