### PR TITLE
Add direct angle controls and restore streamlined exports

### DIFF
--- a/.changeset/select-rendered-joints.md
+++ b/.changeset/select-rendered-joints.md
@@ -1,0 +1,5 @@
+---
+"posecode-render": patch
+---
+
+Add `Viewer.selectBones()` to highlight canonical bones at their live joint positions without affecting bounds, grounding, exports, or diagnostics.

--- a/packages/posecode-render/src/index.ts
+++ b/packages/posecode-render/src/index.ts
@@ -111,6 +111,11 @@ export interface Viewer {
   getConstraintDiagnostics(): readonly ConstraintDiagnostic[];
   /** Precise visible world bounds; intended for audits and deterministic export. */
   getVisibleBounds(): THREE.Box3;
+  /**
+   * Highlight canonical bone ids at their live joint positions. Unknown ids
+   * are ignored; pass an empty list to clear the selection.
+   */
+  selectBones(boneIds: readonly string[]): void;
   getMannequin(): any;
   getCharacter(): any;
   /**
@@ -178,6 +183,46 @@ export function createViewer(
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x0c0f15);
   scene.fog = new THREE.Fog(0x0c0f15, 9, 18);
+
+  // Text-editor selection overlay. Markers live outside the mannequin and
+  // character trees so they never affect grounding, camera framing, bounds,
+  // exports, or contact diagnostics.
+  const boneSelection = new THREE.Group();
+  boneSelection.name = "posecode-bone-selection";
+  scene.add(boneSelection);
+  const selectionDotGeometry = new THREE.SphereGeometry(0.018, 16, 12);
+  const selectionRingGeometry = new THREE.TorusGeometry(0.055, 0.006, 8, 32);
+  const selectionDotMaterial = new THREE.MeshBasicMaterial({
+    color: 0xd4ff3f,
+    transparent: true,
+    opacity: 0.96,
+    depthTest: false,
+    depthWrite: false,
+  });
+  const selectionRingMaterial = new THREE.MeshBasicMaterial({
+    color: 0xd4ff3f,
+    transparent: true,
+    opacity: 0.82,
+    depthTest: false,
+    depthWrite: false,
+  });
+  let selectedBoneIds: string[] = [];
+  let selectionMarkers: THREE.Group[] = [];
+
+  function rebuildBoneSelection(): void {
+    boneSelection.clear();
+    selectionMarkers = selectedBoneIds.map(() => {
+      const marker = new THREE.Group();
+      marker.renderOrder = 1000;
+      const dot = new THREE.Mesh(selectionDotGeometry, selectionDotMaterial);
+      dot.renderOrder = 1000;
+      const ring = new THREE.Mesh(selectionRingGeometry, selectionRingMaterial);
+      ring.renderOrder = 1000;
+      marker.add(dot, ring);
+      boneSelection.add(marker);
+      return marker;
+    });
+  }
 
   // Image-based environment light: soft bounced light that gives the matte
   // figure materials realistic shading gradients instead of flat CG plastic.
@@ -911,6 +956,23 @@ export function createViewer(
     // geometry; a segmented skin can have a different lowest point as limbs
     // rotate. Reconcile the actual skinned surface after every animation layer.
     if (character && solvedInfo && isFloorBound(solvedInfo)) character.reconcileFloor();
+    // Follow the visible rig (including mocap and its final floor correction)
+    // when available; the congruent procedural driver is the fallback.
+    for (let i = 0; i < selectedBoneIds.length; i++) {
+      const boneId = selectedBoneIds[i]!;
+      const marker = selectionMarkers[i]!;
+      const position =
+        character?.getJointWorldPosition(boneId) ??
+        mannequin.bones.get(boneId)?.getWorldPosition(new THREE.Vector3()) ??
+        null;
+      marker.visible = position !== null;
+      if (position) {
+        marker.position.copy(position);
+        // The torus is a screen-facing selection ring; the centre dot remains
+        // spherical, so copying the camera frame works for both children.
+        marker.quaternion.copy(camera.quaternion);
+      }
+    }
     frameDt = 0;
     if (easeCamera) {
       controls.target.lerp(desiredTarget, 0.07);
@@ -1242,6 +1304,12 @@ export function createViewer(
     getVisibleBounds() {
       return character?.getBounds() ?? new THREE.Box3().setFromObject(mannequin.root);
     },
+    selectBones(boneIds) {
+      selectedBoneIds = [...new Set(boneIds)].filter((id) =>
+        mannequin.bones.has(id),
+      );
+      rebuildBoneSelection();
+    },
     getMannequin() {
       return mannequin;
     },
@@ -1267,6 +1335,10 @@ export function createViewer(
       clipLayer?.dispose();
       character?.dispose();
       floorGuide?.dispose();
+      selectionDotGeometry.dispose();
+      selectionRingGeometry.dispose();
+      selectionDotMaterial.dispose();
+      selectionRingMaterial.dispose();
       renderer.dispose();
     },
   };

--- a/playground/play.html
+++ b/playground/play.html
@@ -182,6 +182,15 @@
       <section class="viewer-pane">
         <canvas id="canvas"></canvas>
         <div class="viewer-veil" aria-hidden="true"></div>
+        <div
+          id="joint-selection"
+          class="joint-selection"
+          aria-live="polite"
+          hidden
+        >
+          <span>selected</span>
+          <strong id="joint-selection-name"></strong>
+        </div>
 
         <div class="hud">
           <div id="phase" class="phase"></div>

--- a/playground/play.html
+++ b/playground/play.html
@@ -101,12 +101,12 @@
         </a>
         <a
           id="feedback"
-          href="https://github.com/posecode-dev/posecode/issues/new"
+          href="https://github.com/posecode-dev/posecode"
           class="btn ghost"
           target="_blank"
           rel="noreferrer"
-          aria-label="Report an issue on GitHub"
-          title="Report an issue on GitHub"
+          aria-label="Open the Posecode repository on GitHub"
+          title="Open the Posecode repository on GitHub"
         >
           <span class="ico-github" aria-hidden="true"></span><span class="lbl">GitHub</span>
         </a>
@@ -121,21 +121,38 @@
         </button>
         <div class="tb-downloads">
           <button
-            id="download-bvh"
+            id="export-menu-button"
             class="btn ghost"
-            aria-label="Download BVH"
-            title="Download the movement as a .bvh motion file for Blender and other tools"
+            type="button"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls="export-menu"
           >
-            <span class="lbl" aria-live="polite">Download BVH</span>
+            <span class="lbl" aria-live="polite">Export</span>
+            <span class="export-caret" aria-hidden="true"></span>
           </button>
-          <button
-            id="download-gltf"
-            class="btn ghost"
-            aria-label="Download glTF"
-            title="Download the movement as a .glb glTF asset (rig + animation) for Three.js and web pipelines"
-          >
-            <span class="lbl" aria-live="polite">Download glTF</span>
-          </button>
+          <div id="export-menu" class="export-menu" role="menu" hidden>
+            <button
+              id="download-bvh"
+              class="export-option"
+              type="button"
+              role="menuitem"
+              title="Download the movement as a .bvh motion file for Blender and other tools"
+            >
+              <span>BVH</span>
+              <small>For Blender and animation tools</small>
+            </button>
+            <button
+              id="download-gltf"
+              class="export-option"
+              type="button"
+              role="menuitem"
+              title="Download the movement as a .glb glTF asset (rig + animation) for Three.js and web pipelines"
+            >
+              <span>glTF / GLB</span>
+              <small>For Three.js and web pipelines</small>
+            </button>
+          </div>
         </div>
         <button
           id="copy-prompt"

--- a/playground/src/direct-manipulation.ts
+++ b/playground/src/direct-manipulation.ts
@@ -1,0 +1,109 @@
+import {
+  ACTION_NAMES,
+  JOINT_NAMES,
+  expandJoint,
+  romFor,
+} from "posecode-parser";
+
+const JOINT_SET = new Set<string>(JOINT_NAMES);
+const ACTION_SET = new Set<string>(ACTION_NAMES);
+
+/**
+ * A directly-manipulable `<joint>: <action> <angle>` source line.
+ * Positions are absolute CodeMirror document offsets and use half-open ranges.
+ */
+export interface AngleTarget {
+  joint: string;
+  action: string;
+  degrees: number;
+  jointFrom: number;
+  jointTo: number;
+  angleFrom: number;
+  angleTo: number;
+}
+
+export interface AngleRange {
+  min: number;
+  max: number;
+}
+
+// Keep this deliberately stricter than syntax highlighting. Only complete,
+// parser-valid joint target lines become controls; comments, turn/travel
+// numbers, and half-written source remain ordinary editable text.
+const JOINT_TARGET =
+  /^(\s*)([A-Za-z][\w-]*)(\s*:\s*)([A-Za-z][\w-]*)(\s+)(-?(?:\d+(?:\.\d*)?|\.\d+))(?=\s*(?:(?:#|\/\/).*)?$)/;
+
+/** Locate every source angle that can safely become an inline control. */
+export function findAngleTargets(source: string): AngleTarget[] {
+  const targets: AngleTarget[] = [];
+  let lineFrom = 0;
+
+  for (const line of source.split(/\n/)) {
+    const match = JOINT_TARGET.exec(line.replace(/\r$/, ""));
+    if (match && JOINT_SET.has(match[2]!) && ACTION_SET.has(match[4]!)) {
+      const joint = match[2]!;
+      const action = match[4]!;
+      // Unsupported joint/action pairs stay plain text so the parser error
+      // remains the primary interaction rather than presenting a bogus range.
+      if (angleRangeFor(joint, action)) {
+        const jointFrom = lineFrom + match[1]!.length;
+        const angleFrom =
+          jointFrom +
+          match[2]!.length +
+          match[3]!.length +
+          match[4]!.length +
+          match[5]!.length;
+        const angleText = match[6]!;
+        targets.push({
+          joint,
+          action,
+          degrees: Number(angleText),
+          jointFrom,
+          jointTo: jointFrom + joint.length,
+          angleFrom,
+          angleTo: angleFrom + angleText.length,
+        });
+      }
+    }
+    // split() removes the newline, so account for it between every pair.
+    lineFrom += line.length + 1;
+  }
+
+  return targets;
+}
+
+/** Find the target whose joint or angle contains a document position. */
+export function angleTargetAt(
+  source: string,
+  position: number,
+  part: "joint" | "angle",
+): AngleTarget | null {
+  for (const target of findAngleTargets(source)) {
+    const from = part === "joint" ? target.jointFrom : target.angleFrom;
+    const to = part === "joint" ? target.jointTo : target.angleTo;
+    if (position >= from && position < to) return target;
+  }
+  return null;
+}
+
+/**
+ * Return the ROM intersection for all bones represented by a DSL joint name.
+ * Groups therefore get one honest range that is valid for every selected bone.
+ */
+export function angleRangeFor(joint: string, action: string): AngleRange | null {
+  const bones = expandJoint(joint);
+  const limits = bones
+    .map((bone) => romFor(bone, action))
+    .filter((limit): limit is AngleRange => limit !== null);
+  if (limits.length === 0 || limits.length !== bones.length) return null;
+
+  const min = Math.max(...limits.map((limit) => limit.min));
+  const max = Math.min(...limits.map((limit) => limit.max));
+  return min <= max ? { min, max } : null;
+}
+
+/** Clamp and format a spinner value without accumulating float noise. */
+export function normalizeAngle(value: number, range: AngleRange): string {
+  const clamped = Math.min(range.max, Math.max(range.min, value));
+  return String(Math.round(clamped * 10) / 10);
+}

--- a/playground/src/editor.ts
+++ b/playground/src/editor.ts
@@ -21,6 +21,7 @@ import {
   hoverTooltip,
   placeholder,
   Decoration,
+  WidgetType,
   type DecorationSet,
 } from "@codemirror/view";
 import {
@@ -61,7 +62,15 @@ import {
   MOVEMENT_KINDS,
   PROP_TYPES,
   START_POSE_NAMES,
+  expandJoint,
 } from "posecode-parser";
+import {
+  angleRangeFor,
+  angleTargetAt,
+  findAngleTargets,
+  normalizeAngle,
+  type AngleTarget,
+} from "./direct-manipulation.js";
 
 // --- Syntax highlighting ----------------------------------------------------
 
@@ -254,6 +263,81 @@ const posecodeTheme = EditorView.theme(
       color: "var(--text-2)",
     },
     ".cm-posecode-hover strong": { color: "var(--text)" },
+    ".cm-joint-link": {
+      cursor: "pointer",
+      borderBottom: "1px dotted rgba(192, 167, 255, 0.72)",
+      borderRadius: "2px",
+      transition: "color 120ms ease, background-color 120ms ease",
+    },
+    ".cm-joint-link:hover": {
+      color: "#dfd2ff",
+      backgroundColor: "rgba(192, 167, 255, 0.12)",
+    },
+    ".cm-joint-selected": {
+      color: "var(--accent)",
+      backgroundColor: "rgba(212, 255, 63, 0.11)",
+      borderBottomColor: "var(--accent)",
+    },
+    ".cm-angle-control": {
+      cursor: "pointer",
+      color: "#ffb184",
+      borderBottom: "1px dotted rgba(255, 157, 107, 0.78)",
+      borderRadius: "2px",
+    },
+    ".cm-angle-control:hover": {
+      color: "#ffd1b7",
+      backgroundColor: "rgba(255, 157, 107, 0.12)",
+    },
+    ".cm-angle-spinner": {
+      display: "inline-flex",
+      alignItems: "center",
+      verticalAlign: "middle",
+      margin: "0 2px",
+      height: "25px",
+      color: "var(--text)",
+      backgroundColor: "var(--panel-3)",
+      border: "1px solid var(--accent)",
+      borderRadius: "3px",
+      boxShadow: "0 0 0 2px rgba(212, 255, 63, 0.08)",
+      overflow: "hidden",
+    },
+    ".cm-angle-input": {
+      width: "5.2ch",
+      height: "100%",
+      padding: "0 2px 0 5px",
+      border: "0",
+      outline: "0",
+      color: "var(--text)",
+      backgroundColor: "transparent",
+      fontFamily: "var(--mono)",
+      fontSize: "12.5px",
+      textAlign: "right",
+    },
+    ".cm-angle-degree": {
+      paddingRight: "3px",
+      color: "var(--text-2)",
+      fontSize: "11px",
+    },
+    ".cm-angle-step": {
+      width: "22px",
+      height: "100%",
+      padding: "0",
+      border: "0",
+      borderRadius: "0",
+      color: "var(--text-2)",
+      backgroundColor: "transparent",
+      fontFamily: "var(--mono)",
+      fontSize: "14px",
+      cursor: "pointer",
+    },
+    ".cm-angle-step:hover": {
+      color: "var(--bg)",
+      backgroundColor: "var(--accent)",
+    },
+    ".cm-angle-step:focus-visible, .cm-angle-input:focus-visible": {
+      outline: "1px solid var(--text)",
+      outlineOffset: "-2px",
+    },
     ".cm-tooltip-autocomplete > ul > li[aria-selected]": {
       backgroundColor: "var(--accent-veil)",
       color: "var(--text)",
@@ -294,6 +378,223 @@ const phaseHighlightField = StateField.define<DecorationSet>({
   provide: (f) => EditorView.decorations.from(f),
 });
 
+// --- Direct manipulation ---------------------------------------------------
+// Joint names and authored degree values are live controls rather than inert
+// syntax. Clicking a joint selects its concrete bones in the viewer; clicking
+// the angle replaces only that number with a compact, ROM-aware spinner.
+
+const setSelectedJoint = StateEffect.define<string | null>();
+const setActiveAngle = StateEffect.define<AngleTarget | null>();
+
+const selectedJointField = StateField.define<string | null>({
+  create: () => null,
+  update(selected, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setSelectedJoint)) selected = effect.value;
+    }
+    if (
+      selected &&
+      tr.docChanged &&
+      !findAngleTargets(tr.state.doc.toString()).some(
+        (target) => target.joint === selected,
+      )
+    ) {
+      return null;
+    }
+    return selected;
+  },
+});
+
+const activeAngleField = StateField.define<AngleTarget | null>({
+  create: () => null,
+  update(active, tr) {
+    if (active && tr.docChanged) {
+      const mapped = tr.changes.mapPos(active.angleFrom, 1);
+      active = angleTargetAt(tr.state.doc.toString(), mapped, "angle");
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(setActiveAngle)) active = effect.value;
+    }
+    return active;
+  },
+});
+
+function replaceActiveAngle(view: EditorView, requested: number): void {
+  const active = view.state.field(activeAngleField);
+  if (!active || !Number.isFinite(requested)) return;
+  const range = angleRangeFor(active.joint, active.action);
+  if (!range) return;
+  const insert = normalizeAngle(requested, range);
+  const current = view.state.doc.sliceString(active.angleFrom, active.angleTo);
+  if (insert === current) return;
+  view.dispatch({
+    changes: {
+      from: active.angleFrom,
+      to: active.angleTo,
+      insert,
+    },
+    effects: setActiveAngle.of({
+      ...active,
+      degrees: Number(insert),
+      angleTo: active.angleFrom + insert.length,
+    }),
+    annotations: Transaction.userEvent.of("input"),
+  });
+}
+
+class AngleSpinnerWidget extends WidgetType {
+  constructor(
+    readonly target: AngleTarget,
+    readonly min: number,
+    readonly max: number,
+  ) {
+    super();
+  }
+
+  eq(other: AngleSpinnerWidget): boolean {
+    return (
+      other.target.joint === this.target.joint &&
+      other.target.action === this.target.action &&
+      other.target.degrees === this.target.degrees &&
+      other.min === this.min &&
+      other.max === this.max
+    );
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const control = document.createElement("span");
+    control.className = "cm-angle-spinner";
+    control.title = `Safe range: ${this.min}–${this.max}°`;
+
+    const minus = document.createElement("button");
+    minus.type = "button";
+    minus.className = "cm-angle-step";
+    minus.textContent = "−";
+    minus.setAttribute("aria-label", `Decrease ${this.target.joint} angle`);
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.className = "cm-angle-input";
+    input.min = String(this.min);
+    input.max = String(this.max);
+    input.step = "1";
+    input.value = String(this.target.degrees);
+    input.setAttribute(
+      "aria-label",
+      `${this.target.joint} ${this.target.action} angle in degrees; safe range ${this.min} to ${this.max}`,
+    );
+
+    const degree = document.createElement("span");
+    degree.className = "cm-angle-degree";
+    degree.textContent = "°";
+    degree.setAttribute("aria-hidden", "true");
+
+    const plus = document.createElement("button");
+    plus.type = "button";
+    plus.className = "cm-angle-step";
+    plus.textContent = "+";
+    plus.setAttribute("aria-label", `Increase ${this.target.joint} angle`);
+
+    const step = (delta: number): void => {
+      const current = Number(input.value);
+      replaceActiveAngle(
+        view,
+        (Number.isFinite(current) ? current : this.target.degrees) + delta,
+      );
+    };
+    minus.addEventListener("click", () => step(-1));
+    plus.addEventListener("click", () => step(1));
+    input.addEventListener("input", () => {
+      if (input.value !== "") replaceActiveAngle(view, Number(input.value));
+    });
+    input.addEventListener("change", () => {
+      if (input.value === "") input.value = String(this.target.degrees);
+    });
+    input.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      view.dispatch({ effects: setActiveAngle.of(null) });
+      view.focus();
+    });
+
+    control.append(minus, input, degree, plus);
+    window.setTimeout(() => {
+      input.focus();
+      input.select();
+    }, 0);
+    return control;
+  }
+
+  updateDOM(dom: HTMLElement): boolean {
+    const input = dom.querySelector<HTMLInputElement>(".cm-angle-input");
+    if (!input) return false;
+    input.min = String(this.min);
+    input.max = String(this.max);
+    if (document.activeElement !== input) {
+      input.value = String(this.target.degrees);
+    }
+    dom.title = `Safe range: ${this.min}–${this.max}°`;
+    return true;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+const directManipulationDecorations = EditorView.decorations.compute(
+  ["doc", selectedJointField, activeAngleField],
+  (state) => {
+    const selected = state.field(selectedJointField);
+    const active = state.field(activeAngleField);
+    const marks = [];
+    for (const target of findAngleTargets(state.doc.toString())) {
+      marks.push(
+        Decoration.mark({
+          class: `cm-joint-link${
+            selected === target.joint ? " cm-joint-selected" : ""
+          }`,
+          attributes: {
+            "data-posecode-joint": target.joint,
+            title: `Select ${target.joint} in the 3D viewer`,
+          },
+        }).range(target.jointFrom, target.jointTo),
+      );
+      if (
+        !active ||
+        active.angleFrom !== target.angleFrom ||
+        active.angleTo !== target.angleTo
+      ) {
+        marks.push(
+          Decoration.mark({
+            class: "cm-angle-control",
+            attributes: {
+              "data-posecode-angle": "true",
+              title: `Adjust ${target.joint} ${target.action}`,
+            },
+          }).range(target.angleFrom, target.angleTo),
+        );
+      }
+    }
+    return Decoration.set(marks, true);
+  },
+);
+
+const angleSpinnerDecoration = EditorView.decorations.compute(
+  [activeAngleField],
+  (state) => {
+    const active = state.field(activeAngleField);
+    if (!active) return Decoration.none;
+    const range = angleRangeFor(active.joint, active.action);
+    if (!range) return Decoration.none;
+    return Decoration.set([
+      Decoration.replace({
+        widget: new AngleSpinnerWidget(active, range.min, range.max),
+      }).range(active.angleFrom, active.angleTo),
+    ]);
+  },
+);
+
 // --- Public API -------------------------------------------------------------
 
 export interface PosecodeEditor {
@@ -307,6 +608,7 @@ export interface PosecodeEditor {
 export interface PosecodeEditorOptions {
   doc: string;
   onChange: (value: string, userInitiated: boolean) => void;
+  onJointSelect?: (joint: string | null, boneIds: readonly string[]) => void;
 }
 
 export function createPosecodeEditor(
@@ -328,6 +630,10 @@ export function createPosecodeEditor(
         new LanguageSupport(posecodeStream),
         syntaxHighlighting(posecodeHighlight),
         phaseHighlightField,
+        selectedJointField,
+        activeAngleField,
+        directManipulationDecorations,
+        angleSpinnerDecoration,
         autocompletion({ override: [posecodeCompletions], icons: false }),
         posecodeLinter,
         lintGutter(),
@@ -338,6 +644,46 @@ export function createPosecodeEditor(
           'Paste a movement from your AI chat here, or start typing:\nposecode exercise "My movement"',
         ),
         EditorView.lineWrapping,
+        EditorView.domEventHandlers({
+          click(event, targetView) {
+            const element = (event.target as Element | null)?.closest<HTMLElement>(
+              "[data-posecode-joint], [data-posecode-angle]",
+            );
+            if (!element || !targetView.dom.contains(element)) {
+              targetView.dispatch({
+                effects: [
+                  setSelectedJoint.of(null),
+                  setActiveAngle.of(null),
+                ],
+              });
+              opts.onJointSelect?.(null, []);
+              return false;
+            }
+
+            const part = element.dataset.posecodeAngle ? "angle" : "joint";
+            const position = targetView.posAtDOM(element, 0);
+            const target = angleTargetAt(
+              targetView.state.doc.toString(),
+              position,
+              part,
+            );
+            if (!target) return false;
+
+            const selectionFrom =
+              part === "angle" ? target.angleFrom : target.jointFrom;
+            const selectionTo =
+              part === "angle" ? target.angleTo : target.jointTo;
+            targetView.dispatch({
+              selection: { anchor: selectionFrom, head: selectionTo },
+              effects: [
+                setSelectedJoint.of(target.joint),
+                setActiveAngle.of(part === "angle" ? target : null),
+              ],
+            });
+            opts.onJointSelect?.(target.joint, expandJoint(target.joint));
+            return true;
+          },
+        }),
         keymap.of([
           ...closeBracketsKeymap,
           ...defaultKeymap,
@@ -368,7 +714,12 @@ export function createPosecodeEditor(
     setValue: (doc: string) => {
       view.dispatch({
         changes: { from: 0, to: view.state.doc.length, insert: doc },
+        effects: [
+          setSelectedJoint.of(null),
+          setActiveAngle.of(null),
+        ],
       });
+      opts.onJointSelect?.(null, []);
     },
     focus: () => view.focus(),
     highlightPhase: (from: number | null, to?: number) => {

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -72,6 +72,8 @@ const jointSelection = $<HTMLDivElement>("joint-selection");
 const jointSelectionName = $<HTMLElement>("joint-selection-name");
 const copyBtn = $<HTMLButtonElement>("copy-prompt");
 const shareBtn = $<HTMLButtonElement>("share");
+const exportMenuButton = $<HTMLButtonElement>("export-menu-button");
+const exportMenu = $<HTMLDivElement>("export-menu");
 const downloadBvhBtn = $<HTMLButtonElement>("download-bvh");
 const downloadGltfBtn = $<HTMLButtonElement>("download-gltf");
 const tabEditor = $<HTMLButtonElement>("tab-editor");
@@ -729,10 +731,10 @@ async function downloadBvh(): Promise<void> {
   const source = editorApi.getValue();
   const { ir, errors } = parse(source);
   if (!ir || errors.length > 0) {
-    flash(downloadBvhBtn, "Fix errors first", "error");
+    flash(exportMenuButton, "Fix errors first", "error");
     return;
   }
-  flash(downloadBvhBtn, "Exporting…", "pending", 0);
+  flash(exportMenuButton, "Exporting…", "pending", 0);
   try {
     const { exportBVH } = await import("posecode-render");
     const bvh = exportBVH(ir);
@@ -745,12 +747,11 @@ async function downloadBvh(): Promise<void> {
     a.click();
     a.remove();
     URL.revokeObjectURL(url);
-    flash(downloadBvhBtn, "Downloaded ✓", "success");
+    flash(exportMenuButton, "Downloaded ✓", "success");
   } catch {
-    flash(downloadBvhBtn, "Export failed", "error");
+    flash(exportMenuButton, "Export failed", "error");
   }
 }
-downloadBvhBtn.addEventListener("click", downloadBvh);
 
 // --- glTF / GLB export ---
 // Bake the current movement into a GLB (rig + animation clip) and download it.
@@ -759,10 +760,10 @@ async function downloadGltf(): Promise<void> {
   const source = editorApi.getValue();
   const { ir, errors } = parse(source);
   if (!ir || errors.length > 0) {
-    flash(downloadGltfBtn, "Fix errors first", "error");
+    flash(exportMenuButton, "Fix errors first", "error");
     return;
   }
-  flash(downloadGltfBtn, "Exporting…", "pending", 0);
+  flash(exportMenuButton, "Exporting…", "pending", 0);
   try {
     const { exportGLTF } = await import("posecode-render");
     const glb = (await exportGLTF(ir, { binary: true })) as ArrayBuffer;
@@ -775,12 +776,45 @@ async function downloadGltf(): Promise<void> {
     a.click();
     a.remove();
     URL.revokeObjectURL(url);
-    flash(downloadGltfBtn, "Downloaded ✓", "success");
+    flash(exportMenuButton, "Downloaded ✓", "success");
   } catch {
-    flash(downloadGltfBtn, "Export failed", "error");
+    flash(exportMenuButton, "Export failed", "error");
   }
 }
-downloadGltfBtn.addEventListener("click", downloadGltf);
+
+// --- Export menu ---
+function setExportMenu(open: boolean): void {
+  exportMenu.hidden = !open;
+  exportMenuButton.setAttribute("aria-expanded", String(open));
+  if (open) downloadBvhBtn.focus();
+}
+exportMenuButton.addEventListener("click", () => {
+  setExportMenu(exportMenu.hasAttribute("hidden"));
+});
+downloadBvhBtn.addEventListener("click", () => {
+  setExportMenu(false);
+  exportMenuButton.focus();
+  void downloadBvh();
+});
+downloadGltfBtn.addEventListener("click", () => {
+  setExportMenu(false);
+  exportMenuButton.focus();
+  void downloadGltf();
+});
+document.addEventListener("click", (event) => {
+  if (!(event.target instanceof Element) || !event.target.closest(".tb-downloads")) {
+    setExportMenu(false);
+  }
+});
+exportMenu.addEventListener("keydown", (event) => {
+  const options = [downloadBvhBtn, downloadGltfBtn];
+  const index = options.indexOf(document.activeElement as HTMLButtonElement);
+  if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+    event.preventDefault();
+    const direction = event.key === "ArrowDown" ? 1 : -1;
+    options[(index + direction + options.length) % options.length]?.focus();
+  }
+});
 
 // --- Slide-over panels (how-to, movement library) sharing one scrim ---
 const howto = $<HTMLElement>("howto");
@@ -815,7 +849,13 @@ $<HTMLButtonElement>("howto-copy").addEventListener("click", (e) =>
   copyPrompt(e.currentTarget as HTMLButtonElement),
 );
 document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") closePanels();
+  if (e.key === "Escape") {
+    closePanels();
+    if (!exportMenu.hidden) {
+      setExportMenu(false);
+      exportMenuButton.focus();
+    }
+  }
 });
 
 // --- Intro strip ---

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -29,6 +29,13 @@ import { ANIMATION_PROGRESS_MESSAGE, PRESETS } from "./presets.js";
 import { prioritizeFeaturedMovement } from "./library-order.js";
 import { SHOWCASE_CLIPS } from "./clips.js";
 
+// During source-only typechecks the playground resolves posecode-render's last
+// built declaration bundle. Keep the local extension explicit until the normal
+// package build regenerates that bundle from the source Viewer interface.
+type InteractiveViewer = Viewer & {
+  selectBones(boneIds: readonly string[]): void;
+};
+
 // Open on a deterministic, fully procedural movement. Mocap-backed or
 // Experimental presets should never be the product's first impression.
 const DEFAULT_PRESET =
@@ -61,6 +68,8 @@ const cueEl = $<HTMLDivElement>("cue");
 const floorGuideKey = $<HTMLDivElement>("floor-guide-key");
 const floorGuideTravel = $<HTMLSpanElement>("floor-guide-travel");
 const floorGuideReset = $<HTMLSpanElement>("floor-guide-reset");
+const jointSelection = $<HTMLDivElement>("joint-selection");
+const jointSelectionName = $<HTMLElement>("joint-selection-name");
 const copyBtn = $<HTMLButtonElement>("copy-prompt");
 const shareBtn = $<HTMLButtonElement>("share");
 const downloadBvhBtn = $<HTMLButtonElement>("download-bvh");
@@ -72,7 +81,7 @@ const tabViewer = $<HTMLButtonElement>("tab-viewer");
 // *after* the editor shell paints (dynamic import → its own chunk) so first
 // paint and interactivity aren't blocked by it. Until `boot()` resolves the
 // import, `viewer` is null and viewer-dependent work is skipped/deferred.
-let viewer: Viewer | null = null;
+let viewer: InteractiveViewer | null = null;
 let scrubbing = false;
 let repeat = 1;
 let rep = 1;
@@ -86,6 +95,24 @@ let lastContactRefresh = 0;
 let scrubDiagnosticsRefresh = 0;
 let documentRevision = 1;
 let pendingRenderTrigger: RenderTrigger = "initial";
+let selectedBoneIds: readonly string[] = [];
+
+/** Keep the source selection and its live 3D joint markers in sync. */
+function handleJointSelect(
+  joint: string | null,
+  boneIds: readonly string[],
+): void {
+  selectedBoneIds = boneIds;
+  viewer?.selectBones(boneIds);
+  jointSelection.hidden = joint === null;
+  if (joint) {
+    const readable = joint.replaceAll("_", " ");
+    jointSelectionName.textContent =
+      boneIds.length > 1 ? `${readable} · ${boneIds.length} bones` : readable;
+  } else {
+    jointSelectionName.textContent = "";
+  }
+}
 
 function documentKind(): DocumentKind {
   if (currentPresetId) return "preset";
@@ -864,6 +891,7 @@ void import("./editor.js").then(({ createPosecodeEditor }) => {
   editorApi = createPosecodeEditor($("editor"), {
     doc: initialDoc,
     onChange: handleEditorChange,
+    onJointSelect: handleJointSelect,
   });
   recompile();
 });
@@ -895,7 +923,8 @@ void import("posecode-render").then(({ createViewer }) => {
     // never slows the default page. Disabled with the classic figure, which has
     // no skinned mesh to retarget onto.
     ...(classicFigure || groundingAuditMode ? {} : { clips: SHOWCASE_CLIPS }),
-  });
+  }) as InteractiveViewer;
+  viewer.selectBones(selectedBoneIds);
   // Exposed for capture/e2e tooling (frame capture drives README GIFs).
   (window as unknown as Record<string, unknown>).__posecodeViewer = viewer;
   if (import.meta.env.DEV) {

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -301,12 +301,60 @@ select:hover {
   align-items: center;
 }
 
-/* The two motion-export buttons are grouped so mobile can lay them out as one
-   balanced row. On desktop the wrapper is transparent (`display: contents`),
-   so the buttons stay direct children of the flex toolbar and the desktop row
-   is unchanged. */
+/* Desktop motion export lives behind one compact menu; mobile hides the whole
+   desktop-pipeline action below. */
 .tb-downloads {
-  display: contents;
+  position: relative;
+}
+.export-caret {
+  width: 7px;
+  height: 7px;
+  margin-left: 2px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 0.16s var(--ease);
+}
+#export-menu-button[aria-expanded="true"] .export-caret {
+  transform: translateY(2px) rotate(225deg);
+}
+.export-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 30;
+  width: 260px;
+  padding: 6px;
+  background:
+    var(--sheen),
+    var(--panel-2);
+  border: 1px solid var(--border-2);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-float);
+}
+.export-option {
+  display: grid;
+  width: 100%;
+  gap: 2px;
+  padding: 10px 11px;
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  cursor: pointer;
+}
+.export-option:hover,
+.export-option:focus-visible {
+  background: var(--panel-3);
+}
+.export-option > span {
+  font-weight: 700;
+}
+.export-option small {
+  color: var(--text-2);
+  font-size: 11px;
 }
 
 /* Movement-library trigger — the one content control in the topbar. Reads like

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -596,6 +596,42 @@ select:hover {
   background: linear-gradient(180deg, rgba(8, 10, 14, 0.6), transparent);
 }
 
+.joint-selection {
+  position: absolute;
+  z-index: 2;
+  top: 18px;
+  left: 50%;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  max-width: min(42vw, 360px);
+  padding: 6px 9px;
+  transform: translateX(-50%);
+  border: 1px solid rgba(212, 255, 63, 0.42);
+  border-radius: 3px;
+  color: var(--text);
+  background: rgba(11, 12, 13, 0.82);
+  backdrop-filter: blur(8px);
+  font-family: var(--mono);
+  pointer-events: none;
+}
+.joint-selection[hidden] {
+  display: none;
+}
+.joint-selection span {
+  color: var(--accent);
+  font-size: 9px;
+  letter-spacing: 0.9px;
+  text-transform: uppercase;
+}
+.joint-selection strong {
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .hud {
   position: absolute;
   top: 18px;

--- a/playground/test/direct-manipulation.test.ts
+++ b/playground/test/direct-manipulation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  angleRangeFor,
+  angleTargetAt,
+  findAngleTargets,
+  normalizeAngle,
+} from "../src/direct-manipulation.js";
+
+describe("direct angle manipulation", () => {
+  const source = [
+    'posecode exercise "Curl"',
+    "  rig humanoid",
+    "  pose start = standing:",
+    "    shoulders: abduct 12.5",
+    '  step "Curl" 1s flow:',
+    "    elbows: flex 90 # the editable target",
+    "    turn: 45",
+    "    wrists: hold neutral",
+    "    knees: abduct 10",
+    "    // shoulders: flex 30",
+  ].join("\n");
+
+  it("finds only complete, supported joint angle lines", () => {
+    const targets = findAngleTargets(source);
+    expect(targets.map(({ joint, action, degrees }) => ({ joint, action, degrees })))
+      .toEqual([
+        { joint: "shoulders", action: "abduct", degrees: 12.5 },
+        { joint: "elbows", action: "flex", degrees: 90 },
+      ]);
+    for (const target of targets) {
+      expect(source.slice(target.jointFrom, target.jointTo)).toBe(target.joint);
+      expect(Number(source.slice(target.angleFrom, target.angleTo))).toBe(target.degrees);
+    }
+  });
+
+  it("resolves clicks independently for joint names and angle values", () => {
+    const target = findAngleTargets(source)[1]!;
+    expect(angleTargetAt(source, target.jointFrom + 2, "joint")?.joint).toBe("elbows");
+    expect(angleTargetAt(source, target.angleFrom, "angle")?.degrees).toBe(90);
+    expect(angleTargetAt(source, target.angleTo + 1, "angle")).toBeNull();
+  });
+
+  it("uses the shared safe range for symmetric groups", () => {
+    expect(angleRangeFor("elbows", "flex")).toEqual({ min: 0, max: 154 });
+    expect(angleRangeFor("ankles", "flex")).toBeNull();
+  });
+
+  it("clamps spinner edits and keeps useful decimal precision", () => {
+    const range = { min: 0, max: 154 };
+    expect(normalizeAngle(80.04, range)).toBe("80");
+    expect(normalizeAngle(80.06, range)).toBe("80.1");
+    expect(normalizeAngle(999, range)).toBe("154");
+  });
+});

--- a/playground/test/playground-actions.test.ts
+++ b/playground/test/playground-actions.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "../..");
+const playground = readFileSync(resolve(root, "playground/play.html"), "utf8");
+const main = readFileSync(resolve(root, "playground/src/main.ts"), "utf8");
+
+describe("playground header actions", () => {
+  it("keeps both motion formats behind one Export menu", () => {
+    expect(playground).toContain('id="export-menu-button"');
+    expect(playground).toContain('aria-haspopup="menu"');
+    expect(playground).toContain('id="export-menu"');
+    expect(playground).toContain('id="download-bvh"');
+    expect(playground).toContain('id="download-gltf"');
+    expect(playground.match(/>Download BVH</g)).toBeNull();
+    expect(playground.match(/>Download glTF</g)).toBeNull();
+  });
+
+  it("links the GitHub action to the repository instead of issue creation", () => {
+    expect(playground).toContain('href="https://github.com/posecode-dev/posecode"');
+    expect(playground).not.toContain("posecode-dev/posecode/issues/new");
+    expect(playground).toContain("Open the Posecode repository on GitHub");
+  });
+
+  it("supports dismissal and keyboard navigation for the export menu", () => {
+    expect(main).toContain("function setExportMenu(open: boolean)");
+    expect(main).toContain('event.key === "ArrowDown"');
+    expect(main).toContain('event.key === "ArrowUp"');
+    expect(main).toContain('e.key === "Escape"');
+  });
+});


### PR DESCRIPTION
## What changed

- Make supported Posecode joint names clickable in CodeMirror and resolve joint groups to their concrete bones.
- Add an inline `− / angle / +` spinner for authored joint angles, constrained to the shared range-of-motion limits.
- Add a renderer selection API and live Xbot/classic-figure markers that follow selected joints without affecting bounds, grounding, exports, or diagnostics.
- Show the selected joint in the viewport HUD and clear the selection when the source context changes.
- Add focused tests for source target detection, click ranges, group ROM intersections, clamping, and numeric formatting.
- Restore the streamlined playground header: one accessible Export menu for BVH/glTF and a GitHub action that opens the repository.

## Why

Authors who are not animators should be able to explore a Posecode movement without already knowing anatomical angle values. This brings Bret Victor-style direct manipulation to the text-first workflow while preserving the source document as the single source of truth.

## User impact

Clicking a joint name now identifies it on the 3D figure. Clicking its numeric angle turns the value into an accessible spinner; every change updates the source and re-renders the movement immediately.

The playground also matches the deployed header again: authors see one Export action instead of two competing download buttons, and GitHub opens the project repository rather than issue creation.

## Root cause

The streamlined header existed in commit `d5ec0db`, but that commit remained on `agent/streamline-playground-actions` and never reached `main`. Branches created from `main` therefore restored the older two-button/issue-link UI. This PR carries that commit forward and adds regression coverage.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test -- --run playground/test/playground-actions.test.ts playground/test/direct-manipulation.test.ts playground/test/analytics-wiring.test.ts packages/posecode-render/test/render.test.ts` (56 tests passed)
- Manual browser verification with the production Xbot: selected pelvis marker rendered and `45° → 46°` updated the live pose
- Local/production header comparison: one Export menu with BVH + glTF/GLB options and the repository GitHub URL
